### PR TITLE
Using toolchain config file instead of cmd `rustup default nightly` and fix i32 overflow

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/utils/components/last_chunk_tx_pos.rs
+++ b/src/utils/components/last_chunk_tx_pos.rs
@@ -25,9 +25,9 @@ impl LastChunkTxPos {
     }
 
     pub fn distance_to(&self, x: i32, z: i32) -> f64 {
-        let dx = self.x - x;
-        let dz = self.z - z;
+        let dx = (self.x - x) as f64;
+        let dz = (self.z - z) as f64;
 
-        ((dx * dx + dz * dz) as f64).sqrt()
+        (dx * dx + dz * dz).sqrt()
     }
 }


### PR DESCRIPTION
Using `rust-toolchain.toml` allows you to set the nightly toolchain for a project rather than globally.
And
Fix the i32 overflow issue.