### PR TITLE
Much saner and concurrent event api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ ferrumc-world = { path = "src/lib/world" }
 
 # Asynchronous
 tokio = { version = "1.40.0", features = ["full"] }
-parking_lot = "0.12.3"
+futures = "0.3.30"
 
 # Logging
 tracing = "0.1.40"
@@ -90,9 +90,9 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 log = "0.4.22"
 
 # Concurrency/Parallelism
+parking_lot = "0.12.3"
 rayon = "1.10.0"
 crossbeam = "0.8.4"
-futures = "0.3.30"
 
 # Network
 

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use parking_lot::RwLock;
 use tracing::info;
-use ferrumc_events::infrastructure::{get_event_listeners, Event};
+use ferrumc_events::infrastructure::Event;
 use ferrumc_macros::event_handler;
 
 #[tokio::main]
@@ -13,14 +13,11 @@ async fn main() {
     
     println!("good day to ya. enjoy your time with ferrumc!");
 
-    let some_event = Arc::new(RwLock::new( SomeEvent {
+    let some_event = SomeEvent {
         some_data: 42,
-    }));
+    };
 
-    for listener in get_event_listeners::<SomeEvent>() {
-        listener(some_event.clone()).await;
-    }
-
+    SomeEvent::trigger(some_event).await;
 }
 
 
@@ -29,10 +26,19 @@ struct SomeEvent {
     pub some_data: i32,
 }
 
+#[derive(Debug)]
+pub enum SomeEventError {
+    
+}
+
 impl Event for SomeEvent {
+    type Data = Self;
+    type Error = SomeEventError;
+    
     fn name() -> &'static str {
         "SomeEvent"
     }
+
 }
 
 #[event_handler(priority = "fastest")]

--- a/src/lib/events/Cargo.toml
+++ b/src/lib/events/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
+crossbeam = { workspace = true }
 ctor = { workspace = true}
 parking_lot = { workspace = true }
 hashbrown = { workspace = true }

--- a/src/lib/events/src/errors.rs
+++ b/src/lib/events/src/errors.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
 pub enum EventsError {
-    #[error("Something failed lol")]
-    SomeError,
+    #[error("FerrumC was unable to register the following event `{event_name}` for the following reasons: {error}")]
+    UnableToRegister { event_name: &'static str, error: String },
+    #[error("A listener failed")]
+    ListenerFailed
 }

--- a/src/lib/events/src/infrastructure.rs
+++ b/src/lib/events/src/infrastructure.rs
@@ -1,53 +1,186 @@
-use std::any::Any;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::{Arc, LazyLock};
+use std::{
+    any::Any,
+    future::Future,
+    pin::Pin,
+    sync::LazyLock
+};
+
+use crossbeam::sync::ShardedLock;
+use futures::{future, stream, StreamExt};
 use hashbrown::HashMap;
-use parking_lot::RwLock;
 
-pub trait Event: Send + Sync + 'static {
-    fn name() -> &'static str;
-}
+/// A Lazily initialized HashMap wrapped in a ShardedLock optimized for reads.
+type LazyRwListenerMap<K,V> = LazyLock<ShardedLock<HashMap<K, V>>>;
 
-type ThreadSafeRwLock<E> = Arc<RwLock<E>>;
+type AsyncEventListener<E: Event> = fn(E::Data) -> Pin<Box<dyn Future<Output = Result<E::Data,E::Error>> + Send>>;
 
-type AsyncEventListenerFn<E> = fn(E) -> Pin<Box<dyn Future<Output = ()> + Send>>;
-
-pub struct EventListener<E> {
-    listener: AsyncEventListenerFn<E>,
-    // 0 ~ 255, 0 being run first, 255 being run last
-    priority: u8
-}
-
-/// This is a map of event names to event listeners
+/// This is the global map of event listeners.
+/// It is lazily initialized at runtime.
+/// 
+/// It links an event string name to its set of listeners 
 /// e.g.
 /// {
 ///    "SomeEvent": [listener1, listener2],
 ///   "AnotherEvent": [listener3, listener4]
 /// }
-static EVENTS: LazyLock<RwLock<HashMap<&'static str, Vec<Box<dyn Any + Send + Sync>>>>> = LazyLock::new(|| RwLock::new(HashMap::new()));
+static EVENTS_LISTENERS: LazyRwListenerMap<&'static str, Vec<Box<dyn Any + Send + Sync>>> = LazyLock::new(|| ShardedLock::new(HashMap::new()));
 
-pub fn insert_into_events<E: Event>(ev: AsyncEventListenerFn<ThreadSafeRwLock<E>>, priority: u8) {
-    let name = E::name();
-    let listener = EventListener {
-        listener: ev,
-        priority
-    };
-    EVENTS.write().entry(name).or_insert_with(Vec::new).push(Box::new(listener));
+/// An event listener structure that contains a pointer to an asynchronous event listener
+/// and its priority of execution.
+pub struct EventListener<E: Event> {
+    /// An asynchronous event listener which returns a result with a potentially modified data or error.
+    listener: AsyncEventListener<E>,
+    /// Priority of this listener
+    priority: u8
 }
 
-pub fn get_event_listeners<E: Event>() -> Vec<AsyncEventListenerFn<ThreadSafeRwLock<E>>> {
-    EVENTS
-        .read()
-        .get(E::name())
-        .map(|events| {
-            let mut listeners = events.iter()
-                .filter_map(|boxed| boxed.downcast_ref::<EventListener<ThreadSafeRwLock<E>>>())
-                .collect::<Vec<_>>();
+impl<E: Event> EventListener<E> {
+    /// Trampoline function to convert from Box<Self> to Box<dyn ...>
+    pub fn to_dyn(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
+        self
+    }
+}
 
-            listeners.sort_by_key(|listener| listener.priority);
-            listeners.into_iter()
-                .map(|listener| listener.listener)
-                .collect()
-        }).unwrap_or_default()
+/// Trait that permit to access priority through the help of a function
+pub trait Priority {
+    fn priority(&self) -> u8;
+}
+
+impl<E: Event> Priority for EventListener<E> {
+    fn priority(&self) -> u8 {
+        self.priority
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait Event: Sized + Send + Sync + 'static {
+    
+    /// Event data structure
+    type Data: Send + Sync;
+    
+    /// Event specific error
+    type Error: std::fmt::Debug + Send;
+    
+    /// Stringified name of the event
+    fn name() -> &'static str;
+    
+    /// Trigger an event execution
+    /// 
+    /// This method will pass the data to the listener with the highest priority which
+    /// will give its result to the next one with a lesser priority and so on.
+    /// 
+    /// Returns `Ok(())` if the execution succeeded. `Err(EventsError)` ifa listener failed.
+    async fn trigger(event: Self::Data) -> Result<(),Self::Error> {
+        
+        EVENTS_LISTENERS
+            .read()
+            .unwrap()
+            .get(Self::name())
+            .map(|listeners| {
+                // Convert listeners iterator into Stream
+                stream::iter(listeners.iter())
+                    // Filter only listeners we can downcast into the correct type
+                    .filter_map(|dynlist| async move { dynlist.downcast_ref::<EventListener<Self>>() })
+                    // Trigger listeners in a row
+                    .fold(Ok(event), |intercepted, listener| async move {
+                        if intercepted.is_err() {
+                            intercepted
+                        } else {
+                            (listener.listener)(intercepted.unwrap()).await
+                        }
+                    })
+            })
+            .unwrap()
+            .await?;
+        
+        Ok(())
+    }
+    
+    /// Trigger the execution of an event with concurrency support
+    /// 
+    /// If the event structure supports cloning. This method can be used to execute
+    /// listeners of the same priority concurrently (using tokio::task). This imply a 
+    /// cloning cost at each listener execution. See `Event::trigger` for a more 
+    /// efficient but more linear approach.
+    /// 
+    /// # Mutability policy
+    /// 
+    /// The listeners having the same priority being runned concurrently, there are no
+    /// guarantees in the order of mutation of the event data. 
+    /// 
+    /// It is recommended to ensure listeners of the same priority exclusively update fields
+    /// in the event data that are untouched by other listeners of the same group.
+    async fn trigger_concurrently(event: Self::Data) -> Result<(),Self::Error>
+    where 
+        Self::Data: Clone
+    {
+        
+        let read_guard = EVENTS_LISTENERS
+            .read()
+            .unwrap();
+        let listeners = 
+            read_guard
+            .get(Self::name())
+            .unwrap();
+        
+        // Convert listeners iterator into Stream
+        let mut stream = stream::iter(listeners.iter());
+        
+        let mut priority_join_set = Vec::new();
+        let mut current_priority = 0;
+        
+        while let Some(Some(listener)) = stream.next().await.map(|l| l.downcast_ref::<EventListener<Self>>()) {
+            
+            if listener.priority == current_priority {
+                priority_join_set.push(tokio::spawn((listener.listener)(event.clone())));
+            } 
+            else {
+                // Await over all listeners launched
+                let joined = future::join_all(priority_join_set.iter_mut()).await;
+                
+                // If one listener fail we return the first error
+                if let Some(err) = joined.into_iter().filter_map(|res| res.expect("No task should ever panic!").err()).next() {
+                    return Err(err);
+                }
+                
+                // Update priority to the new listener(s)
+                current_priority = listener.priority;
+                priority_join_set.push(tokio::spawn((listener.listener)(event.clone())));
+            }
+        }
+        
+        Ok(())
+    }
+    
+    /// Register a a new event listener for this event
+    fn register(listener: AsyncEventListener<Self>, priority: u8) {
+        // Create the event listener structure
+        let listener = EventListener::<Self> {
+            listener,
+            priority
+        };
+        
+        // Write guard the event listeners global map
+        let mut map = EVENTS_LISTENERS.write().unwrap();
+        
+        // Remove listeners to sort them
+        let event_listeners = map.remove(Self::name()).unwrap_or_default();
+        
+        // Downcast them to access their priority field
+        let mut sorted_listeners = event_listeners.into_iter()
+            .filter_map(|boxed| boxed.downcast::<EventListener<Self>>().ok())
+            .collect::<Vec<_>>();
+        
+        // Append our new listener
+        sorted_listeners.push(Box::new(listener));
+        
+        // Sort them then recollect them.
+        sorted_listeners.sort_by_key(|listener| listener.priority);
+        let event_listeners: Vec<Box<dyn Any + Send + Sync>> = sorted_listeners.into_iter()
+            .map(|listener| listener.to_dyn())
+            .collect::<Vec<_>>();
+        
+        // Reinsert sorted listeners into global map
+        map.insert(Self::name(), event_listeners);
+    }
 }


### PR DESCRIPTION
The API has undergone the following updates:
- The data structure of events is now required to implement the `Event` trait, which provides the `trigger` asynchronous method and the `register` method.
- Internally, events now utilize a stream to execute listeners in the correct order and pass their results to subsequent listeners, thereby eliminating the need for shared state, which can now be encapsulated within inner data.
- The `RwLock` has been replaced with a `ShardedLock`, as registrations occur only once during the program's lifetime, at startup. This change reduces read overhead at the expense of write overhead.