### PR TITLE
Feature gating the database backends

### DIFF
--- a/src/lib/storage/Cargo.toml
+++ b/src/lib/storage/Cargo.toml
@@ -14,16 +14,20 @@ ferrumc-utils = { workspace = true }
 rand = { workspace = true }
 zstd = { workspace = true }
 brotli = { workspace = true }
-redb = { workspace = true }
+redb = { workspace = true, optional = true }
 tokio = { workspace = true }
 parking_lot = { workspace = true }
 lazy_static = { workspace = true }
-surrealkv = { workspace = true }
-sled = { workspace = true }
+surrealkv = { workspace = true, optional = true }
+sled = { workspace = true, optional = true }
 rocksdb = { workspace = true, optional = true }
 
 [features]
 rocksdb = ["dep:rocksdb"]
+sled = ["dep:sled"]
+surrealkv = ["dep:surrealkv"]
+redb = ["dep:redb"]
+default = ["sled", "surrealkv", "redb"]
 
 
 

--- a/src/lib/storage/Cargo.toml
+++ b/src/lib/storage/Cargo.toml
@@ -20,8 +20,10 @@ parking_lot = { workspace = true }
 lazy_static = { workspace = true }
 surrealkv = { workspace = true }
 sled = { workspace = true }
-rocksdb = { workspace = true }
+rocksdb = { workspace = true, optional = true }
 
+[features]
+rocksdb = ["dep:rocksdb"]
 
 
 

--- a/src/lib/storage/src/backends/mod.rs
+++ b/src/lib/storage/src/backends/mod.rs
@@ -1,5 +1,13 @@
+#[cfg(feature = "redb")]
 pub mod redb;
 #[cfg(feature = "rocksdb")]
 pub mod rocksdb;
+
+#[cfg(feature = "sled")]
 pub mod sled;
+
+#[cfg(feature = "surrealkv")]
 pub mod surrealkv;
+
+#[cfg(not(any(feature = "redb", feature = "rocksdb", feature = "sled", feature = "surrealkv")))]
+compile_error!("At least one storage backend must be enabled");

--- a/src/lib/storage/src/backends/mod.rs
+++ b/src/lib/storage/src/backends/mod.rs
@@ -1,4 +1,5 @@
 pub mod redb;
+#[cfg(feature = "rocksdb")]
 pub mod rocksdb;
 pub mod sled;
 pub mod surrealkv;

--- a/src/lib/storage/src/backends/rocksdb.rs
+++ b/src/lib/storage/src/backends/rocksdb.rs
@@ -48,8 +48,8 @@ impl DatabaseBackend for RocksDBBackend {
                 .map_err(|e| StorageError::WriteError(e.to_string()))?;
             Ok::<(), StorageError>(())
         })
-        .await
-        .expect("Failed to insert data into database")?;
+            .await
+            .expect("Failed to insert data into database")?;
         Ok(())
     }
 
@@ -67,8 +67,8 @@ impl DatabaseBackend for RocksDBBackend {
                 Ok(None)
             }
         })
-        .await
-        .expect("Failed to get data from database")?;
+            .await
+            .expect("Failed to get data from database")?;
         Ok(result)
     }
 
@@ -81,8 +81,8 @@ impl DatabaseBackend for RocksDBBackend {
                 .map_err(|e| StorageError::WriteError(e.to_string()))?;
             Ok::<(), StorageError>(())
         })
-        .await
-        .expect("Failed to delete data from database")?;
+            .await
+            .expect("Failed to delete data from database")?;
         Ok(())
     }
 
@@ -100,8 +100,8 @@ impl DatabaseBackend for RocksDBBackend {
                 .map_err(|e| StorageError::WriteError(e.to_string()))?;
             Ok::<(), StorageError>(())
         })
-        .await
-        .expect("Failed to update data in database")?;
+            .await
+            .expect("Failed to update data in database")?;
         Ok(())
     }
 
@@ -123,8 +123,8 @@ impl DatabaseBackend for RocksDBBackend {
                 Ok(false)
             }
         })
-        .await
-        .expect("Failed to upsert data in database")?;
+            .await
+            .expect("Failed to upsert data in database")?;
         Ok(result)
     }
 
@@ -138,8 +138,8 @@ impl DatabaseBackend for RocksDBBackend {
                 .map_err(|e| StorageError::ReadError(e.to_string()))?;
             Ok(value.is_some())
         })
-        .await
-        .expect("Failed to check if key exists in database")?;
+            .await
+            .expect("Failed to check if key exists in database")?;
         Ok(result)
     }
 
@@ -164,8 +164,8 @@ impl DatabaseBackend for RocksDBBackend {
                 .map_err(|e| StorageError::WriteError(e.to_string()))?;
             Ok::<(), StorageError>(())
         })
-        .await
-        .expect("Failed to batch insert data into database")?;
+            .await
+            .expect("Failed to batch insert data into database")?;
         Ok(())
     }
 
@@ -191,8 +191,8 @@ impl DatabaseBackend for RocksDBBackend {
             }
             Ok(values)
         })
-        .await
-        .expect("Failed to batch get data from database")?;
+            .await
+            .expect("Failed to batch get data from database")?;
         Ok(result)
     }
 

--- a/src/lib/storage/src/backends/surrealkv.rs
+++ b/src/lib/storage/src/backends/surrealkv.rs
@@ -58,7 +58,7 @@ impl DatabaseBackend for SurrealKVBackend {
     async fn get(&mut self, table: String, key: u64) -> Result<Option<Vec<u8>>, StorageError> {
         let mut modified_key = table.as_bytes().to_vec();
         modified_key.extend_from_slice(&key.to_be_bytes());
-        let mut tx = self
+        let tx = self
             .db
             .read()
             .begin()
@@ -116,7 +116,7 @@ impl DatabaseBackend for SurrealKVBackend {
     async fn exists(&mut self, table: String, key: u64) -> Result<bool, StorageError> {
         let mut modified_key = table.as_bytes().to_vec();
         modified_key.extend_from_slice(&key.to_be_bytes());
-        let mut tx = self
+        let tx = self
             .db
             .read()
             .begin()
@@ -158,7 +158,7 @@ impl DatabaseBackend for SurrealKVBackend {
         table: String,
         keys: Vec<u64>,
     ) -> Result<Vec<Option<Vec<u8>>>, StorageError> {
-        let mut tx = self
+        let tx = self
             .db
             .read()
             .begin()

--- a/src/lib/storage/src/benches/databases.rs
+++ b/src/lib/storage/src/benches/databases.rs
@@ -71,7 +71,8 @@ pub fn database_benchmarks(c: &mut Criterion) {
             temps.push(db_file);
             backend
         });
-
+        
+        #[cfg(feature = "rocksdb")]
         let mut rocksdb_backend = runtime.block_on(async {
             let mut db_file = PathBuf::from("R:/temp/rocksdb");
             if !db_file.exists() {
@@ -124,6 +125,7 @@ pub fn database_benchmarks(c: &mut Criterion) {
                 });
             },
         );
+        #[cfg(feature = "rocksdb")]
         write_group.bench_with_input(
             "RocksDB",
             &("test".to_string(), data.clone()),
@@ -149,6 +151,7 @@ pub fn database_benchmarks(c: &mut Criterion) {
             runtime
                 .block_on(sled_backend.insert("test".to_string(), key, data.clone()))
                 .unwrap();
+            #[cfg(feature = "rocksdb")]
             runtime
                 .block_on(rocksdb_backend.insert("test".to_string(), key, data.clone()))
                 .unwrap();
@@ -190,6 +193,7 @@ pub fn database_benchmarks(c: &mut Criterion) {
                 );
             });
         });
+        #[cfg(feature = "rocksdb")]
         read_group.bench_with_input("RocksDB", &("test".to_string()), |b, (table)| {
             b.iter(|| {
                 let key = keys.choose(&mut rand::thread_rng()).unwrap();


### PR DESCRIPTION
Due to rocksdb's insanely long compile time, I have added a rocksdb feature and required it to be enabled for rocksdb to be compiled and used. Since it's off by default it will essentially disable rocksdb integration unless explicitly enabled.