### PR TITLE
Make the databases actually feature-gated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,12 +140,6 @@ flate2 = { version = "1.0.33" }
 zstd = { version = "0.13.2" }
 brotli = "6.0.0"
 
-# Databases
-redb = "2.1.3"
-surrealkv = "0.3.6"
-sled = "0.34.7"
-rocksdb = "0.22.0"
-
 # I/O
 tempfile = "3.12.0"
 

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+rocksdb = ["ferrumc-storage/rocksdb"]
+sled = ["ferrumc-storage/sled"]
+surrealkv = ["ferrumc-storage/surrealkv"]
+redb = ["ferrumc-storage/redb"]
+default = ["sled", "surrealkv", "redb"]
+
 [dependencies]
 thiserror = { workspace = true }
 

--- a/src/lib/storage/Cargo.toml
+++ b/src/lib/storage/Cargo.toml
@@ -14,13 +14,13 @@ ferrumc-utils = { workspace = true }
 rand = { workspace = true }
 zstd = { workspace = true }
 brotli = { workspace = true }
-redb = { workspace = true, optional = true }
 tokio = { workspace = true }
 parking_lot = { workspace = true }
 lazy_static = { workspace = true }
-surrealkv = { workspace = true, optional = true }
-sled = { workspace = true, optional = true }
-rocksdb = { workspace = true, optional = true }
+redb = { version = "2.1.3", optional = true }
+surrealkv = { version = "0.3.6", optional = true }
+sled = { version = "0.34.7" , optional = true }
+rocksdb = { version = "0.22.0" , optional = true }
 
 [features]
 rocksdb = ["dep:rocksdb"]


### PR DESCRIPTION
This removes the database crates out of the workspace and into the `ferrumc-storage` crate. This makes the database feature flags actually work and you can `cargo build --features rocksdb` if you want it, otherwise it doesn't compile anymore.