### PR TITLE
Fixed stop_all_systems creating new systems to destroy

### DIFF
--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -36,17 +36,10 @@ async fn entry() -> Result<()> {
     let all_system_handles = tokio::spawn(definition::start_all_systems(global_state.clone()));
 
     // Start the systems and wait until all of them are done
-    let result_systems = all_system_handles.await?;
+    all_system_handles.await??;
 
-    match result_systems {
-        Ok(systems) => {
-            definition::stop_all_systems(global_state, systems).await?;
-        }
-        Err(e) => {
-            error!("Something went wrong with the systems: {:?}", e);
-        }
-    }
     // Stop all systems
+    definition::stop_all_systems(global_state).await?;
 
     Ok(())
 }

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -1,14 +1,13 @@
 // Security or something like that
 #![forbid(unsafe_code)]
-
 #![feature(slice_as_chunks)]
 
 use ferrumc_ecs::Universe;
-use ferrumc_net::ServerState;
-use std::sync::{Arc};
-use tracing::{error, info};
 use ferrumc_net::server::create_server_listener;
+use ferrumc_net::ServerState;
+use std::sync::Arc;
 use systems::definition;
+use tracing::{error, info};
 
 pub(crate) mod errors;
 mod packet_handlers;
@@ -33,18 +32,24 @@ async fn main() {
 async fn entry() -> Result<()> {
     let state = create_state().await?;
     let global_state = Arc::new(state);
-    
-    let all_systems = tokio::spawn(definition::start_all_systems(Arc::clone(&global_state)));
+
+    let all_system_handles = tokio::spawn(definition::start_all_systems(global_state.clone()));
 
     // Start the systems and wait until all of them are done
-    all_systems.await??;
-    
+    let result_systems = all_system_handles.await?;
+
+    match result_systems {
+        Ok(systems) => {
+            definition::stop_all_systems(global_state, systems).await?;
+        }
+        Err(e) => {
+            error!("Something went wrong with the systems: {:?}", e);
+        }
+    }
     // Stop all systems
-    definition::stop_all_systems(global_state).await?;
 
     Ok(())
 }
-
 
 async fn create_state() -> Result<ServerState> {
     let listener = create_server_listener().await?;

--- a/src/bin/src/systems/definition.rs
+++ b/src/bin/src/systems/definition.rs
@@ -3,8 +3,8 @@ use crate::systems::tcp_listener_system::TcpListenerSystem;
 use crate::systems::ticking_system::TickingSystem;
 use async_trait::async_trait;
 use ferrumc_net::{GlobalState, NetResult};
-use futures::stream::FuturesUnordered;
-use std::sync::Arc;
+use futures::{future::Lazy, stream::FuturesUnordered};
+use std::sync::{Arc, LazyLock};
 use tracing::{debug, debug_span, info, Instrument};
 
 #[async_trait]
@@ -15,6 +15,9 @@ pub trait System: Send + Sync {
     fn name(&self) -> &'static str;
 }
 
+static SYSTEMS: LazyLock<Vec<Arc<dyn System>>> = LazyLock::new(|| {
+    create_systems()
+});
 pub fn create_systems() -> Vec<Arc<dyn System>> {
     vec![
         Arc::new(TcpListenerSystem),
@@ -22,16 +25,15 @@ pub fn create_systems() -> Vec<Arc<dyn System>> {
         Arc::new(TickingSystem),
     ]
 }
-pub async fn start_all_systems(state: GlobalState) -> NetResult<Vec<Arc<dyn System>>> {
-    let systems = create_systems();
+pub async fn start_all_systems(state: GlobalState) -> NetResult<()> {
     let handles = FuturesUnordered::new();
-    let return_systems = systems.clone(); // all the arcs point to the same values as the original systems
 
-    for system in systems {
+    for system in SYSTEMS.iter() {
         let name = system.name();
 
         let handle = tokio::spawn(
             system
+                .clone()
                 .start(state.clone())
                 .instrument(debug_span!("sys", %name)),
         );
@@ -40,15 +42,15 @@ pub async fn start_all_systems(state: GlobalState) -> NetResult<Vec<Arc<dyn Syst
 
     futures::future::join_all(handles).await;
 
-    Ok(return_systems)
+    Ok(())
 }
 
-pub async fn stop_all_systems(state: GlobalState, systems: Vec<Arc<dyn System>>) -> NetResult<()> {
+pub async fn stop_all_systems(state: GlobalState) -> NetResult<()> {
     info!("Stopping all systems...");
 
-    for system in systems {
+    for system in SYSTEMS.iter() {
         debug!("Stopping system: {}", system.name());
-        system.stop(state.clone()).await;
+        system.clone().stop(state.clone()).await;
     }
 
     Ok(())

--- a/src/bin/src/systems/definition.rs
+++ b/src/bin/src/systems/definition.rs
@@ -3,7 +3,7 @@ use crate::systems::tcp_listener_system::TcpListenerSystem;
 use crate::systems::ticking_system::TickingSystem;
 use async_trait::async_trait;
 use ferrumc_net::{GlobalState, NetResult};
-use futures::{future::Lazy, stream::FuturesUnordered};
+use futures::stream::FuturesUnordered;
 use std::sync::{Arc, LazyLock};
 use tracing::{debug, debug_span, info, Instrument};
 


### PR DESCRIPTION
I have not tested this properly yet since we don't have exit logic yet. I don't see any reason why it would break anything though.