### PR TITLE
Added broadcasting packets with options. And GlobalState Extension trait to easily `state.broadcast(&packet, opts).await;`

### DIFF
--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -1,5 +1,6 @@
 // Security or something like that
 #![forbid(unsafe_code)]
+extern crate core;
 
 use ferrumc_ecs::Universe;
 use ferrumc_net::server::create_server_listener;

--- a/src/lib/ecs/src/lib.rs
+++ b/src/lib/ecs/src/lib.rs
@@ -66,4 +66,8 @@ impl Universe {
     pub fn query<Q: QueryItem>(&self) -> Query<Q> {
         Query::new(&self.components)
     }
+    
+    pub fn get_component_manager(&self) -> &ComponentManager {
+        &self.components
+    }
 }

--- a/src/lib/net/Cargo.toml
+++ b/src/lib/net/Cargo.toml
@@ -26,3 +26,4 @@ serde_json = { workspace = true }
 serde_derive = { workspace = true }
 rand = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+async-trait = { workspace = true }

--- a/src/lib/net/src/lib.rs
+++ b/src/lib/net/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 use tokio::net::TcpListener;
 use ferrumc_ecs::Universe;
 use ferrumc_macros::bake_packet_registry;

--- a/src/lib/net/src/utils/broadcast.rs
+++ b/src/lib/net/src/utils/broadcast.rs
@@ -1,0 +1,111 @@
+use std::future::Future;
+use std::pin::Pin;
+use async_trait::async_trait;
+use futures::StreamExt;
+use tracing::debug;
+use ferrumc_ecs::entities::Entity;
+use ferrumc_net_codec::encode::{NetEncode, NetEncodeOpts};
+use crate::{GlobalState, NetResult};
+use crate::connection::StreamWriter;
+
+type AsyncCallbackFn = Box<dyn Fn(Entity, &GlobalState) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> + Send + Sync>;
+type SyncCallbackFn = Box<dyn Fn(Entity, &GlobalState) + Send + Sync>;
+
+#[derive(Default)]
+pub struct BroadcastOptions {
+    pub only_entities: Option<Vec<Entity>>,
+    pub async_callback: Option<AsyncCallbackFn>,
+    pub sync_callback: Option<SyncCallbackFn>,
+}
+
+impl BroadcastOptions {
+    pub fn only(mut self, entities: Vec<Entity>) -> Self {
+        self.only_entities = Some(entities);
+        self
+    }
+
+    pub fn all(mut self) -> Self {
+        self.only_entities = None;
+        self
+    }
+
+    pub fn with_async_callback<F, Fut>(mut self, f: F) -> Self
+    where
+        F: Fn(Entity, &GlobalState) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.async_callback = Some(Box::new(move |entity, state| {
+            Box::pin(f(entity, state))
+        }));
+        self
+    }
+
+    pub fn with_sync_callback<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Entity, &GlobalState) + Send + Sync + 'static,
+    {
+        self.sync_callback = Some(Box::new(f));
+        self
+    }
+}
+
+pub async fn broadcast(packet: &impl NetEncode, state: &GlobalState, opts: BroadcastOptions) -> NetResult<()> {
+    let entities = match opts.only_entities {
+        None => state.universe.get_component_manager().get_entities_with::<StreamWriter>(),
+        Some(entities) => entities
+    };
+
+    // Pre-encode the packet to save resources.
+    let packet = {
+        let mut buffer = Vec::new();
+        packet.encode(&mut buffer, &NetEncodeOpts::WithLength)?;
+
+        buffer
+    };
+
+    let (state, packet, async_callback, sync_callback) = (state, packet, opts.async_callback, opts.sync_callback);
+
+    futures::stream::iter(entities.into_iter())
+        .fold((state, packet, async_callback, sync_callback), move |(state, packet, async_callback, sync_callback), entity| {
+            async move {
+                let Ok(mut writer) = state.universe.get_mut::<StreamWriter>(entity) else {
+                    return (state, packet, async_callback, sync_callback);
+                };
+
+                if let Err(e) = writer
+                    .send_packet(&packet, &NetEncodeOpts::None)
+                    .await
+                {
+                    debug!("Error sending packet: {}", e);
+                }
+
+                // Execute sync callback first if it exists
+                if let Some(ref callback) = sync_callback {
+                    callback(entity, state);
+                }
+
+                // Then execute async callback if it exists
+                if let Some(ref callback) = async_callback {
+                    callback(entity, state).await;
+                }
+
+                (state, packet, async_callback, sync_callback)
+            }
+        }).await;
+
+    Ok(())
+}
+
+
+
+#[async_trait]
+pub trait BroadcastToAll {
+    async fn broadcast(&self, packet: &(impl NetEncode + Sync), opts: BroadcastOptions) -> NetResult<()>;
+}
+
+#[async_trait]
+impl BroadcastToAll for GlobalState {
+    async fn broadcast(&self, packet: &(impl NetEncode + Sync), opts: BroadcastOptions) -> NetResult<()> {
+        broadcast(packet, self, opts).await
+    }
+}

--- a/src/lib/net/src/utils/mod.rs
+++ b/src/lib/net/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod ecs_helpers;
+pub mod broadcast;


### PR DESCRIPTION
Better broadcasting. You can simply do `state.broadcast(&packet, options);` and it broadcasts to either: All entities, or specifically the entities mentioned with the `BroadcastOptions::default().only(entities);`. Can also have both `Sync` and `Async` callbacks using 
```rs
BroadcastOptions::default().with_async_callback(|entity, state| async move {
// do whatever
});
```
Or for `Sync` callbaks
```rs
BroadcastOptions::default().with_sync_callback(move |entity, state| {
// do whatever
});
```