### PR TITLE
Made query return `(Entity=usize, Item)` instead of `Item` use FERRUMC_LOG for logging.

### DIFF
--- a/src/lib/ecs/src/components/storage.rs
+++ b/src/lib/ecs/src/components/storage.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 use dashmap::DashMap;
 use dashmap::mapref::one::{Ref, RefMut};
@@ -94,5 +95,18 @@ impl<T> DerefMut for ComponentRefMut<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         #[allow(clippy::explicit_auto_deref)]
         &mut *self.guard
+    }
+}
+
+
+impl<T: Component+Debug> Debug for ComponentRef<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.guard.fmt(f)
+    }
+}
+
+impl<T: Component+Debug> Debug for ComponentRefMut<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.guard.fmt(f)
     }
 }

--- a/src/lib/ecs/src/query.rs
+++ b/src/lib/ecs/src/query.rs
@@ -113,7 +113,7 @@ mod iter_impl {
         Q: QueryItem + Send,
         Q::Item<'a>: Send,
     {
-        type Item = Q::Item<'a>;
+        type Item = (Entity, Q::Item<'a>);
 
         fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where
@@ -121,7 +121,10 @@ mod iter_impl {
         {
             self.entities
                 .into_par_iter()
-                .filter_map(|entity| Q::fetch(entity, self.component_storage).ok())
+                .filter_map(|entity| {
+                    let item = Q::fetch(entity, self.component_storage);
+                    item.ok().map(|item| (entity, item))
+                })
                 .drive_unindexed(consumer)
         }
     }

--- a/src/lib/ecs/src/query.rs
+++ b/src/lib/ecs/src/query.rs
@@ -114,7 +114,7 @@ mod iter_impl {
         Q: QueryItem + Send,
         Q::Item<'a>: Send,
     {
-        type Item = (Entity, Q::Item<'a>);
+        type Item = Q::Item<'a>;
 
         fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where
@@ -122,10 +122,7 @@ mod iter_impl {
         {
             self.entities
                 .into_par_iter()
-                .filter_map(move |entity| {
-                    let item = Q::fetch(entity, self.component_storage);
-                    item.ok().map(|item| (entity, item))
-                })
+                .filter_map(|entity| Q::fetch(entity, self.component_storage).ok())
                 .drive_unindexed(consumer)
         }
     }

--- a/src/lib/ecs/src/query.rs
+++ b/src/lib/ecs/src/query.rs
@@ -102,7 +102,6 @@ mod iter_impl {
                 let Ok(item) = Q::fetch(entity, self.component_storage) else {
                     continue;
                 };
-                // return Some(item);
                 return Some((entity, item));
             }
             None
@@ -137,15 +136,13 @@ mod multi_impl {
         where
             $($T: QueryItem,)*
         {
-            // type Item<'a> = ($($T::Item<'a>,)*);
-            type Item<'a> = (Entity, $($T::Item<'a>,)*);
+            type Item<'a> = ($($T::Item<'a>,)*);
 
             fn fetch<'a>(
                 entity: Entity,
                 storage: &ComponentManager
             ) -> ECSResult<Self::Item<'a>> {
-                // Ok(($($T::fetch(entity, storage)?,)*))
-                Ok((entity, $($T::fetch(entity, storage)?,)*))
+                Ok(($($T::fetch(entity, storage)?,)*))
             }
 
             fn entities(

--- a/src/lib/ecs/src/tests/mod.rs
+++ b/src/lib/ecs/src/tests/mod.rs
@@ -37,7 +37,7 @@ fn test_basic() {
     }
     let query = Query::<(&Player, &mut Position)>::new(&component_storage);
     
-    ParallelIterator::for_each(query.into_par_iter(), |(_player, position)| {
+    ParallelIterator::for_each(query.into_par_iter(), |(_eid, _player, position)| {
         let sleep_duration = Duration::from_millis(100 * (position.x as u64));
         thread::sleep(sleep_duration);
     });

--- a/src/lib/ecs/src/tests/mod.rs
+++ b/src/lib/ecs/src/tests/mod.rs
@@ -37,7 +37,7 @@ fn test_basic() {
     }
     let query = Query::<(&Player, &mut Position)>::new(&component_storage);
     
-    ParallelIterator::for_each(query.into_par_iter(), |(_eid, _player, position)| {
+    ParallelIterator::for_each(query.into_par_iter(), |(_eid, (_player, position))| {
         let sleep_duration = Duration::from_millis(100 * (position.x as u64));
         thread::sleep(sleep_duration);
     });

--- a/src/lib/utils/logging/src/lib.rs
+++ b/src/lib/utils/logging/src/lib.rs
@@ -11,9 +11,10 @@ const LOG_LEVEL: &str = "trace";
 
 pub fn init_logging() {
     let trace_level = {
-        let trace_level = std::env::args()
+        /*let trace_level = std::env::args()
             .find(|arg| arg.starts_with("--log="))
-            .map(|arg| arg.replace("--log=", ""));
+            .map(|arg| arg.replace("--log=", ""));*/
+        let trace_level = std::env::var("FERRUMC_LOG").ok();
 
         let trace_level = trace_level.unwrap_or_else(|| LOG_LEVEL.to_string());
 

--- a/src/lib/world/src/errors.rs
+++ b/src/lib/world/src/errors.rs
@@ -40,7 +40,7 @@ impl From<std::io::Error> for WorldError {
     fn from(err: std::io::Error) -> Self {
         match err.kind() {
             ErrorKind::PermissionDenied => PermissionError(err.to_string()),
-            ErrorKind::ReadOnlyFilesystem => PermissionError(err.to_string()),
+            // ErrorKind::ReadOnlyFilesystem => PermissionError(err.to_string()),
             _ => GenericIOError(err.to_string()),
         }
     }


### PR DESCRIPTION
^
Returns (usize, Item) instead of (Item) so you can get more components of an entity using the EntityId.