### PR TITLE
PersistentDataContainers (PDC) Implementation

### DIFF
--- a/src/lib/pdc/src/lib.rs
+++ b/src/lib/pdc/src/lib.rs
@@ -2,16 +2,22 @@ use std::marker::PhantomData;
 
 use serde::{Serialize, de::DeserializeOwned};
 
+use crate::container::PersistentDataContainer;
+
 pub mod container;
 pub mod errors;
-pub mod load;
-pub mod save;
 
 #[cfg(test)]
 mod tests;
 
 pub trait PersistentContainer: Serialize + DeserializeOwned {}
 impl<T> PersistentContainer for T where T: Serialize + DeserializeOwned {}
+
+pub trait PersistentDataHolder {
+    fn get_persistent_data(&self) -> &PersistentDataContainer;
+
+    fn edit_persistent_data<F: FnOnce(&mut PersistentDataContainer)>(&mut self, func: F);
+}
 
 pub struct PersistentKey<T> {
     pub identifier: String,

--- a/src/lib/pdc/src/load.rs
+++ b/src/lib/pdc/src/load.rs
@@ -1,9 +1,0 @@
-use crate::{container::PersistentDataContainer, errors::PersistentDataError};
-
-pub struct PersistentContainerLoader;
-
-impl PersistentContainerLoader {
-    pub fn load_from_file(path: &str) -> Result<PersistentDataContainer, PersistentDataError> {
-        todo!()
-    }
-}

--- a/src/lib/pdc/src/tests.rs
+++ b/src/lib/pdc/src/tests.rs
@@ -1,18 +1,31 @@
-use crate::{PersistentKey, container::PersistentDataContainer};
+use crate::{PersistentDataHolder, PersistentKey, container::PersistentDataContainer};
+
+#[derive(Default)]
+struct PlayerTesting {
+    data: PersistentDataContainer,
+}
+
+impl PersistentDataHolder for PlayerTesting {
+    fn get_persistent_data(&self) -> &PersistentDataContainer {
+        &self.data
+    }
+
+    fn edit_persistent_data<F: FnOnce(&mut PersistentDataContainer)>(&mut self, func: F) {
+        func(&mut self.data);
+    }
+}
 
 #[test]
 fn something() {
+    let mut testing = PlayerTesting::default();
     let testing_key = PersistentKey::<i32>::new("minecraft", "testing");
-    let mut persistent_data = PersistentDataContainer::default();
 
-    persistent_data.set(&testing_key, 10);
+    testing.edit_persistent_data(|data| {
+        data.set(&testing_key, 100);
+    });
 
-    match persistent_data.get(&testing_key) {
-        Ok(testing_value) => {
-            println!("Testing: {}", testing_value);
-        }
-        Err(e) => {
-            println!("{:?}", e);
-        }
+    let persistent_data = testing.get_persistent_data();
+    if let Ok(grabbed_value) = persistent_data.get(&testing_key) {
+        println!("Testing: {}", grabbed_value);
     }
 }


### PR DESCRIPTION
Introduces `PersistentDataContainer` system to support per-entity, per-block, and other persistent data storage mechanisms within Ferrumc. This system is designed to allow developers to safely store and retrieve custom data across various server objects using a type-erased, flexible, and serializable structure.

**Key Features**
- `PersistentDataContainer` Structure:
  - Stores key-value pairs where keys are strings (Identifiers) and values (`serde_json::Value`) types, supporting flexible, type-safe serialization.
  - Includes a `type_map` for optional runtime type tracking (useful for debugging and ensuring type consistency).
- `PersistentDataHolder` Trait:
  - Provides read-only access to the persistent data via `get_persistent_data`.
  - Provides controlled, in-place mutation via `edit_persistent_data` using a closure to ensure thread-safe and idiomatic data editing.
- Serialization Support
  - `PersistentDataContainer` supports `serde` serialization/deserialization to allow saving and loading persistent data easily work world files or other storage backends.
- Runtime Type Awareness
  - Includes a `HashMap<String, TypeId>` to track the expected type of each key at runtime if needed, improving safety and debugging visibility.
  
**Benefits**
- Allows entities, players, blocks, and other server components to store custom persistent data.
- Enables plugin developers to easily attach additional state to objects without modifying core structures.
- Supports safe, type-aware data access patterns to minimize runtime errors.
- Flexible serialization with `serde_json` for potential storage in NBT, JSON, or database formats.

**Example Usages**
```rs
player.edit_persistent_data(|data| {
    data.set("score", 1500);
});

let score = player.get_persistent_data().get::<i32>("score").unwrap_or(0);
```
```rs
use crate::{PersistentDataHolder, PersistentKey, container::PersistentDataContainer};

#[derive(Default)]
struct PlayerTesting {
    data: PersistentDataContainer,
}

impl PersistentDataHolder for PlayerTesting {
    fn get_persistent_data(&self) -> &PersistentDataContainer {
        &self.data
    }

    fn edit_persistent_data<F: FnOnce(&mut PersistentDataContainer)>(&mut self, func: F) {
        func(&mut self.data);
    }
}

#[test]
fn something() {
    let mut testing = PlayerTesting::default();
    let testing_key = PersistentKey::<i32>::new("minecraft", "testing");

    testing.edit_persistent_data(|data| {
        data.set(&testing_key, 100);
    });

    let persistent_data = testing.get_persistent_data();
    if let Ok(grabbed_value) = persistent_data.get(&testing_key) {
        println!("Testing: {}", grabbed_value);
    }
}
```

**Future Improvements**
- Add fine-grained type constraints to `PersistentDataContainer` to improve compile-time type safety.
- Implement custom serializers to support direct NBT encoding.
- Add a utility API for type-checked retrieval (`get_as<T>`) and automatic casting.
- Provide integration hooks for saving persistent data with world and entity files.

**Notes**
- This system is intentionally designed to closely align with Minecraft’s PaperMC `PersistentDataContainer` while leveraging Rust’s type system and memory safety guarantees.
- The API is flexible and can be extended to support advanced use cases like versioning, migration, and custom serialization formats.