### PR TITLE
refactor(bin): switch to ferrumc-scheduler driven game loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "src/lib/world_gen",
     "src/lib/utils/threadpool",
     "src/lib/registry",
+    "src/lib/scheduler",
 ]
 
 #================== Lints ==================#
@@ -102,6 +103,7 @@ ferrumc-net-encryption = { path = "src/lib/net/crates/encryption" }
 ferrumc-plugins = { path = "src/lib/plugins" }
 ferrumc-profiling = { path = "src/lib/utils/profiling" }
 ferrumc-registry = { path = "src/lib/registry" }
+ferrumc-scheduler = { path = "src/lib/scheduler" }
 ferrumc-state = { path = "src/lib/core/state" }
 ferrumc-storage = { path = "src/lib/storage" }
 ferrumc-text = { path = "src/lib/text" }

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -11,6 +11,7 @@ thiserror = { workspace = true }
 
 ferrumc-core = { workspace = true }
 bevy_ecs = { workspace = true }
+ferrumc-scheduler = { workspace = true }
 
 ferrumc-net = { workspace = true }
 ferrumc-net-codec = { workspace = true }

--- a/src/bin/src/packet_handlers/play_packets/keep_alive.rs
+++ b/src/bin/src/packet_handlers/play_packets/keep_alive.rs
@@ -3,7 +3,7 @@ use bevy_ecs::system::Query;
 use ferrumc_core::conn::keepalive::KeepAliveTracker;
 use ferrumc_net::IncomingKeepAlivePacketReceiver;
 use ferrumc_state::GlobalStateResource;
-use std::time::SystemTime;
+use std::time::Instant;
 use tracing::{error, warn};
 
 pub fn handle(
@@ -26,7 +26,7 @@ pub fn handle(
                 .players
                 .disconnect(eid, Some("Invalid keep alive packet received".to_string()));
         } else {
-            keep_alive_tracker.last_received_keep_alive = SystemTime::now();
+            keep_alive_tracker.last_received_keep_alive = Instant::now();
             keep_alive_tracker.has_received_keep_alive = true;
         }
     }

--- a/src/bin/src/systems/keep_alive_system.rs
+++ b/src/bin/src/systems/keep_alive_system.rs
@@ -6,46 +6,51 @@ use std::time::{Duration, SystemTime};
 use tracing::warn;
 
 pub fn keep_alive_system(
-    query: Query<(Entity, &mut KeepAliveTracker, &StreamWriter)>,
+    mut query: Query<(Entity, &mut KeepAliveTracker, &StreamWriter)>,
     state: Res<GlobalStateResource>,
 ) {
-    // Get the times before the queries, since it's possible a query takes more than a millisecond with a lot of entities.
+    let now = std::time::Instant::now(); // faster than SystemTime for diffs
+    const TIMEOUT: Duration = Duration::from_secs(15);
+    const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 
-    let current_time = SystemTime::now();
-
-    for (entity, mut keep_alive_tracker, stream_writer) in query {
+    for (entity, mut tracker, stream_writer) in query.iter_mut() {
+        // Skip if connection is already closed
         if !stream_writer
             .running
             .load(std::sync::atomic::Ordering::Relaxed)
         {
             continue;
         }
-        // If it's been more than 15 seconds since the last keep alive packet was received, kill the connection
-        let time_diff = current_time
-            .duration_since(keep_alive_tracker.last_received_keep_alive)
-            .expect("SystemTime::duration_since failed, this should never happen");
-        if time_diff > Duration::from_secs(15) {
+
+        let elapsed = now.duration_since(tracker.last_received_keep_alive);
+
+        // Kill connection if timed out
+        if elapsed > TIMEOUT {
             warn!(
                 "Killing connection for {}, it's been {:?} since last keepalive response",
-                entity, time_diff
+                entity, elapsed
             );
             state
                 .0
                 .players
                 .disconnect(entity, Some("Connection timed out".to_string()));
-        } else if time_diff >= Duration::from_secs(10) && keep_alive_tracker.has_received_keep_alive
-        {
-            // If it's been more than 10 seconds since the last keep alive packet was sent, send a new one
-            let time_stamp = rand::random();
-            let keep_alive_packet =
+            continue;
+        }
+
+        // Send keepalive if needed
+        if elapsed >= KEEPALIVE_INTERVAL && tracker.has_received_keep_alive {
+            let timestamp = rand::random::<i64>(); // or use a counter
+            let packet =
                 ferrumc_net::packets::outgoing::keep_alive::OutgoingKeepAlivePacket {
-                    timestamp: time_stamp,
+                    timestamp,
                 };
-            if let Err(err) = stream_writer.send_packet_ref(&keep_alive_packet) {
+
+            if let Err(err) = stream_writer.send_packet_ref(&packet) {
                 warn!("Failed to send keep alive packet to {}: {:?}", entity, err);
             }
-            keep_alive_tracker.last_sent_keep_alive = time_stamp;
-            keep_alive_tracker.has_received_keep_alive = false;
+
+            tracker.last_sent_keep_alive = timestamp;
+            tracker.has_received_keep_alive = false;
         }
     }
 }

--- a/src/bin/src/systems/mod.rs
+++ b/src/bin/src/systems/mod.rs
@@ -1,19 +1,17 @@
 pub mod connection_killer;
 mod cross_chunk_boundary;
-mod keep_alive_system;
+pub mod keep_alive_system;
 mod mq;
 pub mod new_connections;
-mod player_count_update;
+pub mod player_count_update;
 pub mod send_chunks;
 pub mod shutdown_systems;
-mod world_sync;
+pub mod world_sync;
 
 pub fn register_game_systems(schedule: &mut bevy_ecs::schedule::Schedule) {
-    schedule.add_systems(keep_alive_system::keep_alive_system);
+    // Tick-bound systems only (run every game tick)
     schedule.add_systems(new_connections::accept_new_connections);
     schedule.add_systems(cross_chunk_boundary::cross_chunk_boundary);
-    schedule.add_systems(player_count_update::player_count_updater);
-    schedule.add_systems(world_sync::sync_world);
     schedule.add_systems(mq::process);
 
     // Should always be last

--- a/src/bin/src/systems/new_connections.rs
+++ b/src/bin/src/systems/new_connections.rs
@@ -7,7 +7,7 @@ use ferrumc_core::transform::position::Position;
 use ferrumc_core::transform::rotation::Rotation;
 use ferrumc_net::connection::NewConnection;
 use ferrumc_state::GlobalStateResource;
-use std::time::SystemTime;
+use std::time::Instant;
 use tracing::{error, trace};
 
 #[derive(Resource)]
@@ -32,7 +32,7 @@ pub fn accept_new_connections(
             new_connection.player_identity.clone(),
             KeepAliveTracker {
                 last_sent_keep_alive: 0,
-                last_received_keep_alive: SystemTime::now(),
+                last_received_keep_alive: Instant::now(),
                 has_received_keep_alive: true,
             },
         ));

--- a/src/bin/src/systems/player_count_update.rs
+++ b/src/bin/src/systems/player_count_update.rs
@@ -8,11 +8,7 @@ pub fn player_count_updater(
     query: Query<(Entity, &PlayerIdentity)>,
     mut cooldown_tracker: ResMut<PlayerCountUpdateCooldown>,
 ) {
-    // This list is more than likely to be updated on every join/leave event, but we do a manual
-    // refresh every 10 seconds in case something desyncs
-    if cooldown_tracker.last_update.elapsed().as_secs() < 10 {
-        return;
-    }
+    // Frequency is controlled by the schedule period.
     state.0.players.player_list.clear();
     for (entity, player_identity) in query.iter() {
         let uuid = player_identity.uuid;

--- a/src/bin/src/systems/world_sync.rs
+++ b/src/bin/src/systems/world_sync.rs
@@ -7,19 +7,13 @@ pub fn sync_world(state: Res<GlobalStateResource>, mut last_synced: ResMut<World
         return;
     }
 
-    // Check if the world needs to be synced
-    if last_synced.last_synced.elapsed().as_secs() >= 15 {
-        tracing::info!("Syncing world...");
-        // Fire off a task to sync the world in the thread pool since syncing the world doesn't need
-        // to be completed straight away, and we don't want to block the main thread
-        let _handle = state.0.thread_pool.oneshot({
-            let state = state.0.clone();
-            move || {
-                state.world.sync().expect("Failed to sync world");
-            }
-        });
+    // Always schedule a sync; frequency is handled by the schedule period.
+    let _handle = state.0.thread_pool.oneshot({
+        let state = state.0.clone();
+        move || {
+            state.world.sync().expect("Failed to sync world");
+        }
+    });
 
-        // Update the last synced time
-        last_synced.last_synced = std::time::Instant::now();
-    }
+    last_synced.last_synced = std::time::Instant::now();
 }

--- a/src/lib/core/src/conn/keepalive.rs
+++ b/src/lib/core/src/conn/keepalive.rs
@@ -1,9 +1,9 @@
 use bevy_ecs::prelude::Component;
-use std::time::SystemTime;
+use std::time::Instant;
 
 #[derive(Component)]
 pub struct KeepAliveTracker {
     pub last_sent_keep_alive: i64,
-    pub last_received_keep_alive: SystemTime,
+    pub last_received_keep_alive: Instant,
     pub has_received_keep_alive: bool,
 }

--- a/src/lib/scheduler/Cargo.toml
+++ b/src/lib/scheduler/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ferrumc-scheduler"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+once_cell = "1.21.3"
+bevy_ecs = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/lib/scheduler/src/lib.rs
+++ b/src/lib/scheduler/src/lib.rs
@@ -1,0 +1,104 @@
+use bevy_ecs::schedule::Schedule;
+use once_cell::sync::Lazy;
+use std::{
+    borrow::Cow,
+    cmp::Reverse,
+    collections::BinaryHeap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct ScheduleId(pub usize);
+
+pub type ScheduleBuilder = Box<dyn FnOnce(&mut Schedule) + Send + 'static>;
+
+pub struct TimedSchedule {
+    pub name: Cow<'static, str>,
+    pub period: Duration,
+    pub next_run: Instant,
+    pub schedule: Schedule,
+}
+
+impl TimedSchedule {
+    pub fn new<N, F>(name: N, period: Duration, build: F) -> Self
+    where
+        N: Into<Cow<'static, str>>,
+        F: FnOnce(&mut Schedule),
+    {
+        let mut s = Schedule::default();
+        build(&mut s);
+        TimedSchedule {
+            name: name.into(),
+            period,
+            next_run: Instant::now(), // run immediately first time
+            schedule: s,
+        }
+    }
+}
+
+pub struct Scheduler {
+    pub schedules: Vec<TimedSchedule>,
+    queue: BinaryHeap<(Reverse<Instant>, usize)>,
+}
+
+impl Scheduler {
+    pub fn new() -> Self {
+        Scheduler {
+            schedules: Vec::new(),
+            queue: BinaryHeap::new(),
+        }
+    }
+
+    pub fn register(&mut self, schedule: TimedSchedule) -> ScheduleId {
+        let id = ScheduleId(self.schedules.len());
+        self.queue
+            .push((Reverse(schedule.next_run), id.0));
+        self.schedules.push(schedule);
+        id
+    }
+
+    pub fn pop_next_due(&mut self) -> Option<(usize, Instant)> {
+        self.queue
+            .pop()
+            .map(|(Reverse(instant), idx)| (idx, instant))
+    }
+
+    pub fn after_run(&mut self, idx: usize) {
+        // Simple re-schedule policy: schedule again from "now"
+        let now = Instant::now();
+        let next = now + self.schedules[idx].period;
+        self.schedules[idx].next_run = next;
+        self.queue.push((Reverse(next), idx));
+    }
+}
+
+/* ---------- Public registration hub for plugins ---------- */
+
+pub struct PendingSchedule {
+    pub name: Cow<'static, str>,
+    pub period: Duration,
+    pub builder: ScheduleBuilder,
+}
+
+static PENDING: Lazy<Mutex<Vec<PendingSchedule>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
+
+pub fn register_timed_schedule<N, F>(name: N, period: Duration, builder: F)
+where
+    N: Into<Cow<'static, str>>,
+    F: FnOnce(&mut Schedule) + Send + 'static,
+{
+    let mut guard = PENDING.lock().expect("pending schedules lock poisoned");
+    guard.push(PendingSchedule {
+        name: name.into(),
+        period,
+        builder: Box::new(builder),
+    });
+}
+
+pub fn drain_registered_schedules() -> Vec<PendingSchedule> {
+    let mut guard = PENDING.lock().expect("pending schedules lock poisoned");
+    let drained = guard.drain(..).collect::<Vec<_>>();
+    drained
+}


### PR DESCRIPTION

#192 

<details>
<summary>Details</summary>

- Replace fixed-tick loop with TimedSchedule driven loop.
- Add tick, world_sync, player_count_refresh, and keepalive schedules.
- Register plugin-provided schedules and preserve shutdown flow.
- Move world_sync and player_count_update out of the per-tick path.
- Expose keep_alive_system, world_sync, and player_count_update as pub.
- chore(bin): add ferrumc-scheduler as bin workspace dependency.
- chore(root): include ferrumc-scheduler as workspace member.
- refactor(world_sync): always schedule; frequency controlled by schedule.
- refactor(player_count_update): remove hard-coded 10s cooldown.- Replace fixed-tick loop with TimedSchedule driven loop.
- Add tick, world_sync, player_count_refresh, and keepalive schedules.
- Register plugin-provided schedules and preserve shutdown flow.
- Move world_sync and player_count_update out of the per-tick path.
- Expose keep_alive_system, world_sync, and player_count_update as pub.
- chore(bin): add ferrumc-scheduler as bin workspace dependency.
- chore(root): include ferrumc-scheduler as workspace member.
- refactor(world_sync): always schedule; frequency controlled by schedule.
- refactor(player_count_update): remove hard-coded 10s cooldown.

</details>