### PR TITLE
refactor: change log level depending on debug_assertions

### DIFF
--- a/src/bin/src/cli.rs
+++ b/src/bin/src/cli.rs
@@ -6,7 +6,9 @@ pub struct CLIArgs {
     #[command(subcommand)]
     pub command: Option<Command>,
     #[clap(long)]
-    #[arg(value_enum, default_value_t = LogLevel(Level::DEBUG))]
+    #[arg(value_enum)]
+    #[cfg_attr(debug_assertions, arg(default_value_t = LogLevel(Level::DEBUG)))]
+    #[cfg_attr(not(debug_assertions), arg(default_value_t = LogLevel(Level::INFO)))]
     pub log: LogLevel,
 }
 

--- a/src/lib/utils/logging/src/lib.rs
+++ b/src/lib/utils/logging/src/lib.rs
@@ -10,7 +10,9 @@ use tracing_subscriber::EnvFilter;
 
 pub fn init_logging(trace_level: Level) {
     //let console = console_subscriber::spawn();
-    let env_filter = EnvFilter::from_default_env().add_directive(trace_level.into());
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(trace_level.into())
+        .parse_lossy("");
 
     let file_appender = tracing_appender::rolling::Builder::new()
         .rotation(Rotation::DAILY)


### PR DESCRIPTION
# Description
- Use `Level::Info` by default on release builds
- Use `Level::Debug` by default on debug builds
- Don't read `RUST_LOG`, as it was overridden right after.