### PR TITLE
fix: Allow cargo to use cached packages

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 defaults:
   run:
     shell: bash
@@ -29,8 +27,6 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
       - name: Run Clippy
@@ -62,8 +58,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
Previously manually written cache was preventing cargo from reusing it. Using Swatinem/rust-cache@v2 allowed to half the runtime of ci job.

This cache is using rustc version and Cargo.lock for cache key, but these are changing every day (unpinned nightly), and on minor package update (no Cargo.lock in repository). So the use of it will be limited.