### PR TITLE
fix: Use iterators instead of loops

### DIFF
--- a/src/lib/derive_macros/Cargo.toml
+++ b/src/lib/derive_macros/Cargo.toml
@@ -22,3 +22,6 @@ craftflow-nbt = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 bitcode = { workspace = true }
 simd-json = { workspace = true }
+
+[dev-dependencies]
+ferrumc-world = { workspace = true }

--- a/src/lib/derive_macros/src/block/mod.rs
+++ b/src/lib/derive_macros/src/block/mod.rs
@@ -1,9 +1,10 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use simd_json::prelude::{ValueAsObject, ValueAsScalar, ValueObjectAccess};
+use simd_json::{OwnedValue, StaticNode};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{braced, Expr, Ident, LitStr, Result, Token};
+use syn::{braced, Expr, Ident, Lit, LitStr, Result, Token};
 
 const JSON_FILE: &[u8] = include_bytes!("../../../../../assets/data/blockstates.json");
 
@@ -73,179 +74,147 @@ pub fn block(input: TokenStream) -> TokenStream {
         .as_object()
         .unwrap()
         .iter()
-        .filter(|v| {
-            let name_in_json = v.1.get("name");
-            if let Some(resolved_name) = name_in_json {
-                resolved_name.as_str() == Some(&name_str)
-            } else {
-                false
-            }
-        })
-        .map(|v| (v.0.parse::<u32>().unwrap(), v.1))
+        .filter(|(_, v)| v.get("name").as_str() == Some(&name_str))
+        .map(|(k, v)| (k.parse::<u32>().unwrap(), v))
         .collect::<Vec<_>>();
-    if let Some(opts) = opts {
-        let mut props = vec![];
-        for kv in opts.pairs.iter() {
-            let key = kv.key.to_string();
-            let value = match &kv.value {
-                Expr::Lit(expr_lit) => {
-                    if let syn::Lit::Str(lit_str) = &expr_lit.lit {
-                        lit_str.value()
-                    } else if let syn::Lit::Bool(lit_bool) = &expr_lit.lit {
-                        lit_bool.value.to_string()
-                    } else if let syn::Lit::Int(lit_int) = &expr_lit.lit {
-                        lit_int.base10_digits().to_string()
-                    } else {
-                        return syn::Error::new_spanned(
+
+    let Some(opts) = opts else {
+        if filtered_names.is_empty() {
+            return syn::Error::new_spanned(
+                name.clone(),
+                format!("block '{}' not found in blockstates.json", name_str),
+            )
+            .to_compile_error()
+            .into();
+        }
+        if filtered_names.len() > 1 {
+            let properties = get_properties(&filtered_names);
+            return syn::Error::new_spanned(
+                name_str.clone(),
+                format!(
+                    "block '{}' has multiple variants, please specify properties. Available properties: {}",
+                    name_str, pretty_print_props(&properties)
+                ),
+            )
+            .to_compile_error()
+            .into();
+        }
+        let first = filtered_names.iter().next().unwrap().0;
+        return quote! { BlockId(#first) }.into();
+    };
+
+    let props = opts
+        .pairs
+        .iter()
+        .map(|kv| {
+            Ok((
+                kv.key.to_string(),
+                match &kv.value {
+                    Expr::Lit(v) => match &v.lit {
+                        Lit::Str(v) => v.value(),
+                        Lit::Bool(v) => v.value.to_string(),
+                        Lit::Int(v) => v.base10_digits().to_string(),
+                        _ => return Err(syn::Error::new_spanned(
                             &kv.value,
                             "only string, bool, and int literals are supported as property values",
-                        )
-                        .to_compile_error()
-                        .into();
+                        )),
+                    },
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            &kv.value,
+                            "only string, bool, and int literals are supported as property values",
+                        ))
                     }
+                },
+            ))
+        })
+        .collect::<Result<std::collections::HashMap<String, String>>>();
+
+    let props = match props {
+        Ok(props) => props,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    let matched = filtered_names
+        .iter()
+        .filter(|(_, v)| {
+            if let Some(map) = v.get("properties").as_object() {
+                // eq impl from halfbwown
+                if map.len() != props.len() {
+                    return false;
                 }
-                _ => {
-                    return syn::Error::new_spanned(
-                        &kv.value,
-                        "only string, bool, and int literals are supported as property values",
-                    )
+                return map.iter().all(|(key, value)| {
+                    let converted = match value {
+                        OwnedValue::Static(StaticNode::Bool(v)) => v.to_string(),
+                        OwnedValue::Static(StaticNode::I64(v)) => v.to_string(),
+                        OwnedValue::String(v) => v.to_string(),
+                        _ => return false,
+                    };
+                    props.get(key).is_some_and(|v| *converted == *v)
+                });
+            }
+            false
+        })
+        .map(|(id, _)| *id)
+        .collect::<Vec<u32>>();
+
+    if matched.is_empty() {
+        let properties = get_properties(&filtered_names);
+        if properties.is_empty() {
+            return syn::Error::new_spanned(
+                name_str.clone(),
+                format!(
+                    "block '{}' has no properties but the following properties were given: {}",
+                    name_str.clone(),
+                    pretty_print_given_props(opts)
+                ),
+            )
+            .to_compile_error()
+            .into();
+        } else {
+            return syn::Error::new_spanned(
+                    name_str.clone(),
+                    format!(
+                        "no variant of block '{}' matches the specified properties. Available properties: {}",
+                        name_str.clone(), pretty_print_props(&properties)
+                    ),
+                )
                     .to_compile_error()
                     .into();
-                }
-            };
-            props.push((key, value));
         }
-        let mut matched = vec![];
-        'outer: for (id, v) in filtered_names.clone() {
-            if let Some(obj) = v.as_object() {
-                if let Some(block_props) = obj.get("properties").and_then(|p| p.as_object()) {
-                    for (k, v) in block_props.iter() {
-                        // Convert to a string
-                        let converted = if let Some(s) = v.as_str() {
-                            s.to_string()
-                        } else if let Some(b) = v.as_bool() {
-                            b.to_string()
-                        } else if let Some(n) = v.as_i64() {
-                            n.to_string()
-                        } else {
-                            // unsupported property type
-                            continue 'outer;
-                        };
-                        // property is a single string
-                        if let Some((_, val)) = props.iter().find(|(key, _)| key == k) {
-                            if converted != *val {
-                                continue 'outer; // no match
-                            }
-                        } else {
-                            continue 'outer; // property not specified
-                        }
-                    }
-                    matched.push(id);
-                } else if !props.is_empty() {
-                    continue 'outer; // properties specified but block has none
-                } else {
-                    matched.push(id); // no properties to match, accept this block
-                }
-            }
-        }
-        if matched.len() > 1 {
-            syn::Error::new_spanned(
+    }
+    if matched.len() > 1 {
+        return syn::Error::new_spanned(
                 name_str.clone(),
                 format!("block '{}' with specified properties has multiple variants, please refine properties", name_str),
             )
                 .to_compile_error()
-                .into()
-        } else if matched.is_empty() {
-            if get_properties_for_id(name_str.clone()).is_empty() {
-                syn::Error::new_spanned(
-                    name_str.clone(),
-                    format!(
-                        "block '{}' has no properties but the following properties were given: {}",
-                        name_str.clone(),
-                        pretty_print_given_props(opts)
-                    ),
-                )
-                .to_compile_error()
-                .into()
-            } else {
-                syn::Error::new_spanned(
-                    name_str.clone(),
-                    format!(
-                        "no variant of block '{}' matches the specified properties. Available properties: {}",
-                        name_str.clone(), pretty_print_props(&get_properties_for_id(name_str))
-                    ),
-                )
-                    .to_compile_error()
-                    .into()
-            }
-        } else {
-            let res = matched[0];
-            quote! { BlockId(#res) }.into()
-        }
-    } else if filtered_names.len() > 1 {
-        syn::Error::new_spanned(
-            name_str.clone(),
-            format!(
-                "block '{}' has multiple variants, please specify properties. Available properties: {}",
-                name_str.clone(), pretty_print_props(&get_properties_for_id(name_str))
-            ),
-        )
-        .to_compile_error()
-        .into()
-    } else if filtered_names.is_empty() {
-        syn::Error::new_spanned(
-            name.clone(),
-            format!("block '{}' not found in blockstates.json", name_str),
-        )
-        .to_compile_error()
-        .into()
-    } else {
-        let first = filtered_names[0].0;
-        quote! { BlockId(#first) }.into()
+                .into();
     }
+
+    let res = matched[0];
+    quote! { BlockId(#res) }.into()
 }
 
-fn get_properties_for_id(id: String) -> Vec<(String, String)> {
-    // Iterate all blocks and find all with this as the "name" field
-    let mut buf = JSON_FILE.to_vec();
-    let v = simd_json::to_owned_value(&mut buf).unwrap();
-    let filtered_names = v
-        .as_object()
-        .unwrap()
+fn get_properties(filtered_names: &[(u32, &OwnedValue)]) -> Vec<(String, String)> {
+    filtered_names
         .iter()
-        .filter(|v| {
-            let name_in_json = v.1.get("name");
-            if let Some(resolved_name) = name_in_json {
-                resolved_name.as_str() == Some(&id)
-            } else {
-                false
-            }
+        .filter_map(|(_, v)| v.get("properties").and_then(|v| v.as_object()))
+        .flat_map(|v| {
+            v.iter().filter_map(|(k, v)| {
+                let converted = match v {
+                    OwnedValue::Static(StaticNode::Bool(v)) => v.to_string(),
+                    OwnedValue::Static(StaticNode::I64(v)) => v.to_string(),
+                    OwnedValue::String(v) => v.to_string(),
+                    _ => return None,
+                };
+                Some((k.clone(), converted))
+            })
         })
-        .map(|v| (v.0.parse::<u32>().unwrap(), v.1))
-        .collect::<Vec<_>>();
-    let mut all_props = vec![];
-    for (_, v) in filtered_names {
-        if let Some(obj) = v.as_object() {
-            if let Some(block_props) = obj.get("properties").and_then(|p| p.as_object()) {
-                for (k, v) in block_props.iter() {
-                    let converted = if let Some(s) = v.as_str() {
-                        s.to_string()
-                    } else if let Some(b) = v.as_bool() {
-                        b.to_string()
-                    } else if let Some(n) = v.as_i64() {
-                        n.to_string()
-                    } else {
-                        continue; // unsupported property type
-                    };
-                    all_props.push((k.clone(), converted));
-                }
-            }
-        }
-    }
-    all_props
+        .collect()
 }
 
-fn pretty_print_props(props: &Vec<(String, String)>) -> String {
+fn pretty_print_props(props: &[(String, String)]) -> String {
     let mut s = String::new();
     for (k, v) in props {
         s.push_str(&format!("{}: {}, ", k, v));
@@ -258,17 +227,12 @@ fn pretty_print_given_props(props: Opts) -> String {
     for kv in props.pairs.iter() {
         let key = kv.key.to_string();
         let value = match &kv.value {
-            Expr::Lit(expr_lit) => {
-                if let syn::Lit::Str(lit_str) = &expr_lit.lit {
-                    lit_str.value()
-                } else if let syn::Lit::Bool(lit_bool) = &expr_lit.lit {
-                    lit_bool.value.to_string()
-                } else if let syn::Lit::Int(lit_int) = &expr_lit.lit {
-                    lit_int.base10_digits().to_string()
-                } else {
-                    "unsupported".to_string()
-                }
-            }
+            Expr::Lit(v) => match &v.lit {
+                Lit::Str(v) => v.value(),
+                Lit::Bool(v) => v.value.to_string(),
+                Lit::Int(v) => v.base10_digits().to_string(),
+                _ => "unsupported".to_string(),
+            },
             _ => "unsupported".to_string(),
         };
         s.push_str(&format!("{}: {}, ", key, value));

--- a/src/lib/derive_macros/src/lib.rs
+++ b/src/lib/derive_macros/src/lib.rs
@@ -101,11 +101,15 @@ pub fn build_registry_packets(input: TokenStream) -> TokenStream {
 /// A macro to lookup block IDs at compile time.
 ///
 /// Feed in the block name as a string literal, and an optional set of properties as a map.
-/// It will output a `BlockId` struct with the correct ID for that block and properties.
+/// It will output a [`ferrumc_world::block_id::BlockId`] struct with the correct ID for that block and properties.
 /// Usage:
-/// ```ignore
+/// ```
+/// # use ferrumc_world::block_id::BlockId;
+/// # use ferrumc_macros::block;
 /// let block_id = block!("stone");
 /// let another_block_id = block!("minecraft:grass_block", {snowy: true});
+/// assert_eq!(block_id, BlockId(1));
+/// assert_eq!(another_block_id, BlockId(8));
 /// ```
 /// Unfortunately, due to current limitations in Rust's proc macros, you will need to import the
 /// `BlockId` struct manually.


### PR DESCRIPTION
this commit refactors code to use iterators instead of loops in `block!` macro code and fixes ignored test to run properly