### PR TITLE
Add build and artifact upload workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,7 @@ jobs:
         run: cargo audit
   build:
     name: Build and Upload Artifacts
+    if: github.ref == 'refs/heads/master'
     runs-on: ${{ matrix.os }}
     needs: [formatting_and_security, test]
     strategy:
@@ -57,16 +58,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
Reintroduces a GH actions job to build the project for all supported targets and upload the resulting executables as artifacts. The build job depends on formatting, security, and test jobs to ensure code quality to reduce artifact building