### PR TITLE
feat(threadpool): split CPU and I/O threadpools for better performance

### DIFF
--- a/src/bin/src/systems/send_chunks.rs
+++ b/src/bin/src/systems/send_chunks.rs
@@ -38,7 +38,7 @@ pub fn send_chunks(
 
     let mut chunks_sent = 0;
 
-    let mut batch = state.thread_pool.batch();
+    let mut batch = state.thread_pools.cpu_pool.batch();
 
     let is_compressed = conn.compress.load(Ordering::Relaxed);
 

--- a/src/bin/src/systems/world_sync.rs
+++ b/src/bin/src/systems/world_sync.rs
@@ -8,7 +8,7 @@ pub fn sync_world(state: Res<GlobalStateResource>, mut last_synced: ResMut<World
     }
 
     // Always schedule a sync; frequency is handled by the schedule period.
-    let _handle = state.0.thread_pool.oneshot({
+    let _handle = state.0.thread_pools.io_pool.oneshot({
         let state = state.0.clone();
         move || {
             state.world.sync().expect("Failed to sync world");

--- a/src/lib/core/state/src/lib.rs
+++ b/src/lib/core/state/src/lib.rs
@@ -2,7 +2,7 @@ pub mod player_list;
 
 use crate::player_list::PlayerList;
 use bevy_ecs::prelude::Resource;
-use ferrumc_threadpool::ThreadPool;
+use ferrumc_threadpool::ThreadPoolManager;
 use ferrumc_world::World;
 use ferrumc_world_gen::WorldGenerator;
 use std::sync::atomic::AtomicBool;
@@ -14,7 +14,7 @@ pub struct ServerState {
     pub terrain_generator: WorldGenerator,
     pub shut_down: AtomicBool,
     pub players: PlayerList, // (UUID, Username)
-    pub thread_pool: ThreadPool,
+    pub thread_pools: ThreadPoolManager,
     pub start_time: Instant,
 }
 

--- a/src/lib/net/src/conn_init/login.rs
+++ b/src/lib/net/src/conn_init/login.rs
@@ -274,8 +274,8 @@ pub(super) async fn login(
     // =============================================================================================
     // 17 Load and send surrounding chunks within render distance
     let radius = get_global_config().chunk_render_distance as i32;
-
-    let mut batch = state.thread_pool.batch();
+    
+    let mut batch = state.thread_pools.cpu_pool.batch();
 
     for x in -radius..=radius {
         for z in -radius..=radius {

--- a/src/lib/world/src/importing.rs
+++ b/src/lib/world/src/importing.rs
@@ -2,7 +2,7 @@ use crate::errors::WorldError;
 use crate::vanilla_chunk_format::VanillaChunk;
 use crate::World;
 use ferrumc_anvil::load_anvil_file;
-use ferrumc_threadpool::ThreadPool;
+use ferrumc_threadpool::ThreadPoolManager;
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
@@ -37,7 +37,7 @@ impl World {
     pub fn import(
         &mut self,
         import_dir: PathBuf,
-        threadpool: ThreadPool,
+        threadpools: ThreadPoolManager,
     ) -> Result<(), WorldError> {
         check_paths_validity(&import_dir)?;
 
@@ -56,8 +56,8 @@ impl World {
         let start = std::time::Instant::now();
 
         let regions_dir = import_dir.join("region").read_dir()?;
-
-        let mut batch = threadpool.batch();
+        
+        let mut batch = threadpools.cpu_pool.batch();
 
         let arc_self = Arc::new(self.clone());
 


### PR DESCRIPTION
- Add ThreadPoolManager with separate cpu_pool and io_pool
- CPU pool uses all cores for compute-intensive tasks (terrain gen, compression)
- I/O pool single-threaded to avoid LMDB write contention
- Update ServerState to use ThreadPoolManager
- Migrate all threadpool usage to appropriate pool type
- Add documentation for pool usage guidelines