### PR TITLE
Create constants for variants of GameEventPacket

### DIFF
--- a/src/lib/net/src/packets/outgoing/game_event.rs
+++ b/src/lib/net/src/packets/outgoing/game_event.rs
@@ -76,7 +76,8 @@ impl GameEventPacket {
     /// GameEvent packet ID to play the elder guardian mob appearance sound effect.
     pub const PLAY_ELDER_GUARDIAN_MOB_APPEARANCE: u8 = 10;
 
-    /// GameEvent packet ID to enable the respawn screen when the player dies.
+    /// GameEvent packet ID to enable/disable the respawn screen when the player
+    /// dies.
     /// This is used when changing the `doImmediateRespawn` gamerule.
     /// Possible values:
     /// - 0: Enable respawn screen.


### PR DESCRIPTION
Fully-documented `u8` constants for the `GameEventPacket` packet types.

I'm really not sure what else to add here - it's just adding a few constants and replacing some magic numbers with the constants.