### PR TITLE
fix/encryption

### DIFF
--- a/src/lib/net/src/connection.rs
+++ b/src/lib/net/src/connection.rs
@@ -82,8 +82,9 @@ impl StreamWriter {
                 };
 
                 match cmd {
-                    WriterCommand::SendPacket(bytes) => {
+                    WriterCommand::SendPacket(mut bytes) => {
                         // This handles ONLY if there was a writing error to the client.
+                        writer.encrypt_buf(&mut bytes);
                         if let Err(e) = writer.write_all(&bytes).await {
                             error!("Failed to write to client: {:?}", e);
                             running_clone.store(false, Ordering::Relaxed);


### PR DESCRIPTION
I realized that my encryption implementation broke on release builds because of the way that `AsyncWrite::write_all` is implemented. I've changed it so that bytes are encrypted before the call to `write_all` instead of in the call. This should be merged ASAP to fix players not being allowed to connect to the server on release builds.