### PR TITLE
Fix crash on chunk palette resize (>16 blocks) and correct data packing logic

### DIFF
--- a/src/lib/world/src/edits.rs
+++ b/src/lib/world/src/edits.rs
@@ -169,7 +169,7 @@ impl BlockStates {
                 }
 
                 let blocks_per_long = 64 / new_bit_size;
-                let expected_longs = (4096 + blocks_per_long - 1) / blocks_per_long;
+                let expected_longs = 4096usize.div_ceil(blocks_per_long);
                 if new_data.len() != expected_longs {
                     return Err(WorldError::InvalidBlockStateData(format!(
                         "Expected packed data size of {}, but got {}",
@@ -309,7 +309,7 @@ impl Chunk {
                     });
 
                 // judge if we need to resize
-                let required_bits = ((palette.len() as f32).log2().ceil() as u8).max(4).min(15); // 15 is max in minecraft protocol
+                let required_bits = ((palette.len() as f32).log2().ceil() as u8).clamp(4, 15); // 15 is max in minecraft protocol
 
                 let resize = required_bits > *bits_per_block;
 

--- a/src/lib/world/src/edits.rs
+++ b/src/lib/world/src/edits.rs
@@ -304,7 +304,7 @@ impl Chunk {
                     });
 
                 // judge if we need to resize
-                let required_bits = ((palette.len() as f32).log2().ceil() as u8).max(4);
+                let required_bits = ((palette.len() as f32).log2().ceil() as u8).max(4).min(15); // 15 is max in minecraft protocol
                 
                 let resize = required_bits > *bits_per_block;
 
@@ -360,9 +360,7 @@ impl Chunk {
             .map(|(_, count)| *count as u16)
             .sum();
 
-        self.sections
-            .iter_mut()
-            .for_each(|section| section.optimise().unwrap());
+        section.optimise()?;
             
         Ok(())
     }


### PR DESCRIPTION
## Summary 
This PR fixes a critical issue where the server/client would crash or disconnect with ChunkNotFound errors when a chunk section exceeded 16 unique block types (triggering a palette resize from 4 bits to 5 bits). It also includes a minor optimization for the set_block function.

## Necessity 
Previously, placing a 17th unique block type in a chunk caused data corruption. The previous resizing logic did not adhere to Minecraft's LongArray padding rules, and the set_block function had ordering issues that prevented the palette from resizing correctly before writing new data.

## Technical Details
- Updated the logic to respect Minecraft's padding requirement. If a value does not fit in the remaining bits of the current long, it now skips to the next long instead of splitting the bits.
- The code now calculates the required bit size and performs the resize operation after adding the new block to the palette but before attempting to write the block data to the storage array.

## Verification
Successfully connected to the server with the fix applied.

Placed over 20 unique block types within a single chunk section.

Verified that all blocks persisted correctly and no ChunkNotFound errors or disconnections occurred.

Monitored logs to ensure resize logic was triggered correctly without data loss.


Placing over 16 unique blocks:

<img width="2560" height="1494" alt="2025-12-01_19 32 37" src="https://github.com/user-attachments/assets/88c2799c-899a-46c3-8781-e732d50cce5a" />


Connect again:

<img width="2560" height="1494" alt="2025-12-01_19 32 48" src="https://github.com/user-attachments/assets/b8734202-089b-4d0f-8034-0ce75ba4a6a4" />

