### PR TITLE
feat: add fluid simulation with parallel tick evaluation

### DIFF
--- a/src/bin/src/game_loop.rs
+++ b/src/bin/src/game_loop.rs
@@ -249,6 +249,7 @@ fn build_timed_scheduler() -> Scheduler {
     // Uses Burst behavior to catch up if ticks are missed (up to 5 at a time).
     let build_tick = |s: &mut Schedule| {
         s.set_executor_kind(ExecutorKind::SingleThreaded);
+        s.add_systems(crate::systems::tick_counter::handle); // Advance the global tick counter
         register_packet_handlers(s); // Handle incoming packets from players
         register_player_systems(s); // Update player state (position, inventory, etc.)
         register_command_systems(s); // Process queued commands

--- a/src/bin/src/packet_handlers/play_packets/place_block.rs
+++ b/src/bin/src/packet_handlers/play_packets/place_block.rs
@@ -1,5 +1,6 @@
-use bevy_ecs::prelude::{Entity, Query, Res};
+use bevy_ecs::prelude::{Entity, Query, Res, ResMut};
 use ferrumc_core::collisions::bounds::CollisionBounds;
+use ferrumc_core::tick::TickCounter;
 use ferrumc_core::transform::position::Position;
 use ferrumc_net::connection::StreamWriter;
 use ferrumc_net::packets::outgoing::block_change_ack::BlockChangeAck;
@@ -10,6 +11,8 @@ use ferrumc_net_codec::net_types::var_int::VarInt;
 use ferrumc_state::GlobalStateResource;
 use ferrumc_world::pos::BlockPos;
 use tracing::{debug, error, trace};
+
+use crate::systems::fluids::{seed_fluid_tick, FluidScheduler};
 
 use ferrumc_config::server_config::get_global_config;
 use ferrumc_core::mq;
@@ -42,6 +45,8 @@ pub fn handle(
     state: Res<GlobalStateResource>,
     query: Query<(Entity, &StreamWriter, &Inventory, &Hotbar, &Position)>,
     pos_q: Query<(&Position, &CollisionBounds)>,
+    mut fluid_scheduler: ResMut<FluidScheduler>,
+    tick: Res<TickCounter>,
 ) {
     'ev_loop: for (event, eid) in receiver.0.try_iter() {
         let Ok((entity, conn, inventory, hotbar, _)) = query.get(eid) else {
@@ -148,6 +153,14 @@ pub fn handle(
                     }
 
                     chunk.set_block(offset_pos.chunk_block_pos(), *mapped_block_state_id);
+
+                    // Release the chunk write guard before seeding fluid ticks. `chunk` is a
+                    // DashMap RefMut holding the shard lock; because it implements Drop it would
+                    // otherwise stay alive until the end of this scope. `seed_fluid_tick` loads
+                    // the same chunk again, which would re-enter the same shard lock and deadlock
+                    // the tick thread.
+                    drop(chunk);
+
                     let ack_packet = BlockChangeAck {
                         sequence: event.sequence,
                     };
@@ -181,6 +194,24 @@ pub fn handle(
                                 error!("Failed to send block update packet: {:?}", err);
                             }
                         }
+                    }
+
+                    // Seed fluid simulation. If the placed block is itself a fluid it will begin
+                    // to spread; in all cases, neighbouring fluids may need to react to the new
+                    // block (e.g. flow around or be blocked by it). The chunk borrow above is
+                    // released before seeding because seeding loads chunks itself.
+                    let current_tick = tick.get();
+                    let scheduler = &mut fluid_scheduler.0;
+                    seed_fluid_tick(scheduler, &state.0, current_tick, offset_pos);
+                    for neighbour in [
+                        offset_pos + (0, 1, 0),
+                        offset_pos + (0, -1, 0),
+                        offset_pos + (1, 0, 0),
+                        offset_pos + (-1, 0, 0),
+                        offset_pos + (0, 0, 1),
+                        offset_pos + (0, 0, -1),
+                    ] {
+                        seed_fluid_tick(scheduler, &state.0, current_tick, neighbour);
                     }
                 }
             }

--- a/src/bin/src/packet_handlers/play_packets/place_block.rs
+++ b/src/bin/src/packet_handlers/play_packets/place_block.rs
@@ -12,7 +12,7 @@ use ferrumc_state::GlobalStateResource;
 use ferrumc_world::pos::BlockPos;
 use tracing::{debug, error, trace};
 
-use crate::systems::fluids::{seed_fluid_tick, FluidScheduler};
+use crate::systems::fluids::{seed_fluid_tick, ActiveDimension, FluidScheduler};
 
 use ferrumc_config::server_config::get_global_config;
 use ferrumc_core::mq;
@@ -46,6 +46,7 @@ pub fn handle(
     query: Query<(Entity, &StreamWriter, &Inventory, &Hotbar, &Position)>,
     pos_q: Query<(&Position, &CollisionBounds)>,
     mut fluid_scheduler: ResMut<FluidScheduler>,
+    dim: Res<ActiveDimension>,
     tick: Res<TickCounter>,
 ) {
     'ev_loop: for (event, eid) in receiver.0.try_iter() {
@@ -158,7 +159,7 @@ pub fn handle(
                     // DashMap RefMut holding the shard lock; because it implements Drop it would
                     // otherwise stay alive until the end of this scope. `seed_fluid_tick` loads
                     // the same chunk again, which would re-enter the same shard lock and deadlock
-                    // the tick thread.
+                    // the tick thread. Multi-thread is so hard :3
                     drop(chunk);
 
                     let ack_packet = BlockChangeAck {
@@ -202,7 +203,8 @@ pub fn handle(
                     // released before seeding because seeding loads chunks itself.
                     let current_tick = tick.get();
                     let scheduler = &mut fluid_scheduler.0;
-                    seed_fluid_tick(scheduler, &state.0, current_tick, offset_pos);
+                    let dim = *dim;
+                    seed_fluid_tick(scheduler, &state.0, dim, current_tick, offset_pos);
                     for neighbour in [
                         offset_pos + (0, 1, 0),
                         offset_pos + (0, -1, 0),
@@ -211,7 +213,7 @@ pub fn handle(
                         offset_pos + (0, 0, 1),
                         offset_pos + (0, 0, -1),
                     ] {
-                        seed_fluid_tick(scheduler, &state.0, current_tick, neighbour);
+                        seed_fluid_tick(scheduler, &state.0, dim, current_tick, neighbour);
                     }
                 }
             }

--- a/src/bin/src/register_resources.rs
+++ b/src/bin/src/register_resources.rs
@@ -1,8 +1,10 @@
+use crate::systems::fluids::FluidScheduler;
 use crate::systems::new_connections::NewConnectionRecv;
 use bevy_ecs::prelude::World;
 use crossbeam_channel::Receiver;
 use ferrumc_config::server_config::get_global_config;
 use ferrumc_core::chunks::world_sync_tracker::WorldSyncTracker;
+use ferrumc_core::tick::TickCounter;
 use ferrumc_core::time::WorldTime;
 use ferrumc_entities::components::PhysicalRegistry;
 use ferrumc_net::connection::NewConnection;
@@ -20,6 +22,8 @@ pub fn register_resources(
         last_synced: std::time::Instant::now(),
     });
     world.insert_resource(WorldTime::default());
+    world.insert_resource(TickCounter::new());
+    world.insert_resource(FluidScheduler::default());
     world.insert_resource(ServerPerformance::new(get_global_config().tps));
     world.insert_resource(PhysicalRegistry::new());
 }

--- a/src/bin/src/register_resources.rs
+++ b/src/bin/src/register_resources.rs
@@ -1,4 +1,4 @@
-use crate::systems::fluids::FluidScheduler;
+use crate::systems::fluids::{ActiveDimension, FluidScheduler};
 use crate::systems::new_connections::NewConnectionRecv;
 use bevy_ecs::prelude::World;
 use crossbeam_channel::Receiver;
@@ -24,6 +24,7 @@ pub fn register_resources(
     world.insert_resource(WorldTime::default());
     world.insert_resource(TickCounter::new());
     world.insert_resource(FluidScheduler::default());
+    world.insert_resource(ActiveDimension::default());
     world.insert_resource(ServerPerformance::new(get_global_config().tps));
     world.insert_resource(PhysicalRegistry::new());
 }

--- a/src/bin/src/systems/fluids/mod.rs
+++ b/src/bin/src/systems/fluids/mod.rs
@@ -24,19 +24,14 @@ use ferrumc_net_codec::net_types::network_position::NetworkPosition;
 use ferrumc_net_codec::net_types::var_int::VarInt;
 use ferrumc_state::{GlobalState, GlobalStateResource};
 use ferrumc_world::block_state_id::BlockStateId;
+use ferrumc_world::dimension::Dimension;
 use ferrumc_world::fluid::is_fluid;
 use ferrumc_world::fluid::spread::{compute_fluid_tick, BlockView, FluidChange};
-use ferrumc_world::fluid::fluid_state;
+use ferrumc_world::fluid::{fluid_state, FluidKind, FluidRules};
 use ferrumc_world::pos::BlockPos;
 use ferrumc_world::scheduler::{BlockTickScheduler, ScheduledTick, TickKind};
 use std::collections::HashMap;
 use tracing::{error, trace};
-
-/// Tick delay before a seeded or re-scheduled fluid block is evaluated.
-///
-/// Vanilla water updates every 5 ticks; lava is slower, but the simplified model uses a single
-/// delay for now. Kept here (rather than in the algorithm) because timing is a scheduling concern.
-pub const FLUID_TICK_DELAY: u64 = 5;
 
 /// Minimum number of due ticks in a batch before the parallel evaluation path is used.
 ///
@@ -45,9 +40,33 @@ pub const FLUID_TICK_DELAY: u64 = 5;
 /// placed bucket) stay on the fast serial path; large flows fan out across cores.
 pub const PARALLEL_THRESHOLD: usize = 64;
 
-/// The dimension fluids are simulated in. The world currently only models the overworld; this
-/// constant marks the call sites that will need revisiting once multiple dimensions exist.
-const DIMENSION: &str = "overworld";
+/// The dimension the fluid system simulates against.
+///
+/// The world currently only tracks the overworld; this resource is the single seam that lets
+/// [`FluidRules`] pick the right per-dimension parameters (overworld lava is slow and short-range,
+/// Nether lava is fast and long-range, etc.). Once multi-dimension support lands, this can become
+/// a per-world value, or the systems can iterate dimensions, without changing the algorithm.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct ActiveDimension(pub Dimension);
+
+impl Default for ActiveDimension {
+    fn default() -> Self {
+        Self(Dimension::Overworld)
+    }
+}
+
+impl ActiveDimension {
+    #[inline]
+    fn name(self) -> &'static str {
+        self.0.as_str()
+    }
+}
+
+/// Looks up the fluid rules for the block at `pos`, if any. Returns `None` for non-fluid blocks.
+#[inline]
+fn rules_for_block(block: BlockStateId, dim: Dimension) -> Option<FluidRules> {
+    fluid_state(block).map(|s| FluidRules::for_kind(s.kind, dim))
+}
 
 /// ECS resource wrapping the per-chunk block tick scheduler.
 ///
@@ -63,11 +82,12 @@ pub struct FluidScheduler(pub BlockTickScheduler);
 /// which is safe to perform concurrently from multiple threads.
 struct WorldBlockView {
     state: GlobalState,
+    dim: ActiveDimension,
 }
 
 impl BlockView for WorldBlockView {
     fn block_at(&self, pos: BlockPos) -> BlockStateId {
-        match ferrumc_utils::world::load_or_generate_chunk(&self.state, pos.chunk(), DIMENSION) {
+        match ferrumc_utils::world::load_or_generate_chunk(&self.state, pos.chunk(), self.dim.name()) {
             Ok(chunk) => chunk.get_block(pos.chunk_block_pos()),
             Err(err) => {
                 // A failed chunk load is treated as air so the algorithm degrades gracefully
@@ -81,20 +101,27 @@ impl BlockView for WorldBlockView {
 
 /// Schedules a fluid tick for `pos` if it currently contains fluid.
 ///
+/// The delay comes from [`FluidRules::for_kind`] for whatever fluid is at `pos`, so water and
+/// lava (and Nether vs overworld lava) tick at their own cadences.
+///
 /// Intended to be called from block placement/break handlers (and from neighbour updates) to kick
 /// off or continue spreading. No-op for non-fluid blocks.
 pub fn seed_fluid_tick(
     scheduler: &mut BlockTickScheduler,
     state: &GlobalState,
+    dim: ActiveDimension,
     current_tick: u64,
     pos: BlockPos,
 ) {
-    let block = match ferrumc_utils::world::load_or_generate_chunk(state, pos.chunk(), DIMENSION) {
+    let block = match ferrumc_utils::world::load_or_generate_chunk(state, pos.chunk(), dim.name()) {
         Ok(chunk) => chunk.get_block(pos.chunk_block_pos()),
         Err(_) => return,
     };
-    if is_fluid(block) {
-        scheduler.schedule(pos, TickKind::FluidSpread, current_tick, FLUID_TICK_DELAY);
+    if let Some(rules) = rules_for_block(block, dim.0) {
+        scheduler.schedule(pos, TickKind::FluidSpread, current_tick, rules.tick_delay);
+    } else {
+        // Keep the early exit on non-fluid blocks for callers that pass arbitrary positions.
+        debug_assert!(!is_fluid(block), "rules_for_block disagreed with is_fluid");
     }
 }
 
@@ -120,21 +147,23 @@ pub fn seed_on_block_break(
     mut scheduler: ResMut<FluidScheduler>,
     tick: Res<TickCounter>,
     state: Res<GlobalStateResource>,
+    dim: Res<ActiveDimension>,
 ) {
     let current = tick.get();
+    let dim = *dim;
     for event in events.read() {
         let pos = event.position;
         // The broken position itself (in case it is now exposed to a fluid) and its neighbours.
-        seed_fluid_tick(&mut scheduler.0, &state.0, current, pos);
+        seed_fluid_tick(&mut scheduler.0, &state.0, dim, current, pos);
         for neighbour in neighbours(pos) {
-            seed_fluid_tick(&mut scheduler.0, &state.0, current, neighbour);
+            seed_fluid_tick(&mut scheduler.0, &state.0, dim, current, neighbour);
         }
     }
 }
 
 /// Writes a single block change back to the world. Returns true on success.
-fn apply_change(state: &GlobalState, change: &FluidChange) -> bool {
-    match ferrumc_utils::world::load_or_generate_mut(state, change.pos.chunk(), DIMENSION) {
+fn apply_change(state: &GlobalState, dim: ActiveDimension, change: &FluidChange) -> bool {
+    match ferrumc_utils::world::load_or_generate_mut(state, change.pos.chunk(), dim.name()) {
         Ok(mut chunk) => {
             chunk.set_block(change.pos.chunk_block_pos(), change.new_block);
             true
@@ -228,7 +257,11 @@ fn change_priority(change: &FluidChange) -> (u8, i32, u32) {
 /// When the batch is large enough the evaluation (a pure read over the world) is fanned out across
 /// the thread pool; otherwise it runs serially. Either way the result is identical because the read
 /// phase never mutates the world, so no tick observes another tick's changes within the batch.
-fn evaluate_batch(state: &GlobalState, due: &[(ferrumc_world::pos::ChunkPos, Vec<ScheduledTick>)]) -> Vec<FluidChange> {
+fn evaluate_batch(
+    state: &GlobalState,
+    dim: ActiveDimension,
+    due: &[(ferrumc_world::pos::ChunkPos, Vec<ScheduledTick>)],
+) -> Vec<FluidChange> {
     // Flatten the per-chunk groups into a single list of positions to evaluate.
     let positions: Vec<BlockPos> = due
         .iter()
@@ -236,20 +269,34 @@ fn evaluate_batch(state: &GlobalState, due: &[(ferrumc_world::pos::ChunkPos, Vec
         .collect();
 
     if positions.len() < PARALLEL_THRESHOLD {
-        evaluate_serial(state, &positions)
+        evaluate_serial(state, dim, &positions)
     } else {
-        evaluate_parallel(state, &positions)
+        evaluate_parallel(state, dim, &positions)
     }
 }
 
+/// Evaluates a single ticking position against the world, picking the right [`FluidRules`] from
+/// whatever fluid currently sits there. Non-fluid positions produce no changes (the block was
+/// removed or replaced between scheduling and now).
+#[inline]
+fn evaluate_position<V: BlockView>(view: &V, dim: Dimension, pos: BlockPos) -> Vec<FluidChange> {
+    let block = view.block_at(pos);
+    let Some(state) = fluid_state(block) else {
+        return Vec::new();
+    };
+    let rules = FluidRules::for_kind(state.kind, dim);
+    compute_fluid_tick(pos, view, rules)
+}
+
 /// Serial evaluation: computes changes for every position on the calling thread.
-fn evaluate_serial(state: &GlobalState, positions: &[BlockPos]) -> Vec<FluidChange> {
+fn evaluate_serial(state: &GlobalState, dim: ActiveDimension, positions: &[BlockPos]) -> Vec<FluidChange> {
     let view = WorldBlockView {
         state: state.clone(),
+        dim,
     };
     let mut changes = Vec::new();
     for &pos in positions {
-        changes.extend(compute_fluid_tick(pos, &view));
+        changes.extend(evaluate_position(&view, dim.0, pos));
     }
     reduce_changes(changes)
 }
@@ -267,8 +314,8 @@ fn evaluate_serial(state: &GlobalState, positions: &[BlockPos]) -> Vec<FluidChan
 /// is missing, which is not safe to do concurrently (it would contend on the LMDB writer and the
 /// DashMap shard). Pre-warming guarantees the parallel phase only ever hits cached chunks, making
 /// it a genuine read-only phase.
-fn evaluate_parallel(state: &GlobalState, positions: &[BlockPos]) -> Vec<FluidChange> {
-    prewarm_chunks(state, positions);
+fn evaluate_parallel(state: &GlobalState, dim: ActiveDimension, positions: &[BlockPos]) -> Vec<FluidChange> {
+    prewarm_chunks(state, dim, positions);
 
     let worker_count = std::thread::available_parallelism()
         .map(|n| n.get())
@@ -279,10 +326,13 @@ fn evaluate_parallel(state: &GlobalState, positions: &[BlockPos]) -> Vec<FluidCh
         let slice = slice.to_vec();
         let task_state = state.clone();
         batch.execute(move || {
-            let view = WorldBlockView { state: task_state };
+            let view = WorldBlockView {
+                state: task_state,
+                dim,
+            };
             let mut changes = Vec::new();
             for pos in slice {
-                changes.extend(compute_fluid_tick(pos, &view));
+                changes.extend(evaluate_position(&view, dim.0, pos));
             }
             changes
         });
@@ -300,7 +350,7 @@ fn evaluate_parallel(state: &GlobalState, positions: &[BlockPos]) -> Vec<FluidCh
 /// A fluid tick reads the ticking block and its six axis-aligned neighbours, so the set of chunks
 /// touched is each position's chunk plus the chunks of its neighbours. Doing this serially up front
 /// removes all chunk generation/insertion from the parallel phase, leaving only cache reads there.
-fn prewarm_chunks(state: &GlobalState, positions: &[BlockPos]) {
+fn prewarm_chunks(state: &GlobalState, dim: ActiveDimension, positions: &[BlockPos]) {
     use std::collections::HashSet;
     let mut chunks = HashSet::new();
     for &pos in positions {
@@ -312,7 +362,7 @@ fn prewarm_chunks(state: &GlobalState, positions: &[BlockPos]) {
     for chunk_pos in chunks {
         // The result is intentionally discarded; the call's side effect (populating the cache) is
         // what matters. Errors are ignored here and surfaced later when the block is read.
-        let _ = ferrumc_utils::world::load_or_generate_chunk(state, chunk_pos, DIMENSION);
+        let _ = ferrumc_utils::world::load_or_generate_chunk(state, chunk_pos, dim.name());
     }
 }
 
@@ -321,20 +371,33 @@ fn prewarm_chunks(state: &GlobalState, positions: &[BlockPos]) {
 /// Shared by the serial and parallel processing paths so both behave identically once changes have
 /// been computed. Runs on the calling (main) thread, so writes are serial and need no locking
 /// beyond the per-chunk guard taken inside [`apply_change`].
+///
+/// Re-scheduling reads the [`FluidRules`] for the *new* block at each change, so a freshly placed
+/// lava cell gets lava's cadence, even if the original tick that produced the change was scheduled
+/// at the water cadence (e.g. a water tick removing itself adjacent to lava).
 fn apply_changes(
     changes: &[FluidChange],
     scheduler: &mut BlockTickScheduler,
     state: &GlobalState,
+    dim: ActiveDimension,
     current: u64,
     players: &Query<(Entity, &StreamWriter, &Position)>,
 ) {
+    // Fallback delay for changes that turn a fluid into a non-fluid (e.g. drying up). In
+    // practice such changes set `reschedule = false`, but if a future change ever asks to be
+    // rescheduled we still need a defensible delay; water's cadence is the conservative choice.
+    let fallback_delay = FluidRules::for_kind(FluidKind::Water, dim.0).tick_delay;
+
     for change in changes {
-        if !apply_change(state, change) {
+        if !apply_change(state, dim, change) {
             continue;
         }
         broadcast_change(change, state, players);
         if change.reschedule {
-            scheduler.schedule(change.pos, TickKind::FluidSpread, current, FLUID_TICK_DELAY);
+            let delay = rules_for_block(change.new_block, dim.0)
+                .map(|r| r.tick_delay)
+                .unwrap_or(fallback_delay);
+            scheduler.schedule(change.pos, TickKind::FluidSpread, current, delay);
         }
     }
 }
@@ -349,6 +412,7 @@ pub fn process_fluid_ticks(
     mut scheduler: ResMut<FluidScheduler>,
     tick: Res<TickCounter>,
     state: Res<GlobalStateResource>,
+    dim: Res<ActiveDimension>,
     players: Query<(Entity, &StreamWriter, &Position)>,
 ) {
     let current = tick.get();
@@ -358,7 +422,8 @@ pub fn process_fluid_ticks(
     }
 
     let global = &state.0;
-    let changes = evaluate_batch(global, &due);
+    let dim = *dim;
+    let changes = evaluate_batch(global, dim, &due);
     if changes.is_empty() {
         return;
     }
@@ -370,7 +435,7 @@ pub fn process_fluid_ticks(
         changes.len(),
     );
 
-    apply_changes(&changes, &mut scheduler.0, global, current, &players);
+    apply_changes(&changes, &mut scheduler.0, global, dim, current, &players);
 }
 
 #[cfg(test)]
@@ -381,6 +446,13 @@ mod tests {
     use ferrumc_state::create_test_state;
     use ferrumc_world::fluid::{fluid_block, fluid_state, FluidKind};
     use ferrumc_world::pos::BlockPos;
+
+    /// All tests in this module simulate the overworld; this constant keeps the test bodies short
+    /// while still exercising the dimension-aware code path.
+    const TEST_DIM: ActiveDimension = ActiveDimension(Dimension::Overworld);
+    const TEST_DIM_NAME: &str = "overworld";
+    /// Water's overworld cadence — what every test here seeds with.
+    const TEST_DELAY: u64 = 5;
 
     /// Drives the fluid system end-to-end through the ECS, mirroring the real tick schedule
     /// (advance tick counter, then process fluid ticks). Verifies that a seeded water source
@@ -399,7 +471,7 @@ mod tests {
                     let mut chunk = ferrumc_utils::world::load_or_generate_mut(
                         global,
                         BlockPos::of(x, 63, z).chunk(),
-                        DIMENSION,
+                        TEST_DIM_NAME,
                     )
                     .expect("load chunk");
                     chunk.set_block(BlockPos::of(x, 63, z).chunk_block_pos(), block!("stone"));
@@ -407,18 +479,19 @@ mod tests {
             }
             // Place the water source.
             let mut chunk =
-                ferrumc_utils::world::load_or_generate_mut(global, source.chunk(), DIMENSION)
+                ferrumc_utils::world::load_or_generate_mut(global, source.chunk(), TEST_DIM_NAME)
                     .expect("load chunk");
             chunk.set_block(source.chunk_block_pos(), fluid_block(FluidKind::Water, 0));
         }
 
         world.insert_resource(state.clone());
         world.insert_resource(TickCounter::new());
+        world.insert_resource(TEST_DIM);
         let mut sched = FluidScheduler::default();
 
         // Seed the source as the placement handler would.
         let source = BlockPos::of(0, 64, 0);
-        seed_fluid_tick(&mut sched.0, &state.0, 0, source);
+        seed_fluid_tick(&mut sched.0, &state.0, TEST_DIM, 0, source);
         world.insert_resource(sched);
 
         // Build a schedule that mimics the tick: advance counter, then process fluids.
@@ -426,14 +499,14 @@ mod tests {
         schedule.add_systems(crate::systems::tick_counter::handle);
         schedule.add_systems(process_fluid_ticks);
 
-        // Run enough ticks for the source to spread to its neighbours (delay is 5 ticks).
+        // Run enough ticks for the source to spread to its neighbours (water cadence is 5 ticks).
         for _ in 0..30 {
             schedule.run(&mut world);
         }
 
         // Verify a horizontal neighbour now holds flowing water in the live world.
         let neighbour = BlockPos::of(1, 64, 0);
-        let block = ferrumc_utils::world::load_or_generate_chunk(&state.0, neighbour.chunk(), DIMENSION)
+        let block = ferrumc_utils::world::load_or_generate_chunk(&state.0, neighbour.chunk(), TEST_DIM_NAME)
             .expect("load chunk")
             .get_block(neighbour.chunk_block_pos());
         let fluid = fluid_state(block).expect("neighbour should contain water after spreading");
@@ -469,13 +542,19 @@ mod tests {
                 .flat_map(|(_, ticks)| ticks.iter().map(|t| t.pos))
                 .collect();
             let changes = match mode {
-                EvalMode::Serial => evaluate_serial(state, &positions),
-                EvalMode::Parallel => evaluate_parallel(state, &positions),
+                EvalMode::Serial => evaluate_serial(state, TEST_DIM, &positions),
+                EvalMode::Parallel => evaluate_parallel(state, TEST_DIM, &positions),
             };
             for change in &changes {
-                apply_change(state, change);
+                apply_change(state, TEST_DIM, change);
                 if change.reschedule {
-                    scheduler.schedule(change.pos, TickKind::FluidSpread, tick, FLUID_TICK_DELAY);
+                    // Look up the cadence per change, the same way `apply_changes` does in
+                    // production. For the all-water tests in this module this resolves to the
+                    // water delay.
+                    let delay = rules_for_block(change.new_block, TEST_DIM.0)
+                        .map(|r| r.tick_delay)
+                        .unwrap_or(TEST_DELAY);
+                    scheduler.schedule(change.pos, TickKind::FluidSpread, tick, delay);
                 }
             }
         }
@@ -497,7 +576,7 @@ mod tests {
                     let chunk_pos = BlockPos::of(x, 64, z).chunk();
                     if seen.insert((chunk_pos.x(), chunk_pos.z())) {
                         let _ = ferrumc_utils::world::load_or_generate_chunk(
-                            global, chunk_pos, DIMENSION,
+                            global, chunk_pos, TEST_DIM_NAME,
                         )
                         .expect("generate chunk");
                     }
@@ -511,12 +590,12 @@ mod tests {
                 for z in -radius..=radius {
                     global
                         .world
-                        .set_block_and_fetch(BlockPos::of(x, 63, z), DIMENSION, block!("stone"))
+                        .set_block_and_fetch(BlockPos::of(x, 63, z), TEST_DIM_NAME, block!("stone"))
                         .expect("set floor");
                     if x.abs() == radius || z.abs() == radius {
                         global
                             .world
-                            .set_block_and_fetch(BlockPos::of(x, 64, z), DIMENSION, block!("stone"))
+                            .set_block_and_fetch(BlockPos::of(x, 64, z), TEST_DIM_NAME, block!("stone"))
                             .expect("set wall");
                     }
                 }
@@ -525,13 +604,13 @@ mod tests {
                 .world
                 .set_block_and_fetch(
                     BlockPos::of(0, 64, 0),
-                    DIMENSION,
+                    TEST_DIM_NAME,
                     fluid_block(FluidKind::Water, 0),
                 )
                 .expect("set source");
         }
         let mut scheduler = BlockTickScheduler::new();
-        seed_fluid_tick(&mut scheduler, &state.0, 0, BlockPos::of(0, 64, 0));
+        seed_fluid_tick(&mut scheduler, &state.0, TEST_DIM, 0, BlockPos::of(0, 64, 0));
         (state, temp_dir, scheduler)
     }
 
@@ -543,7 +622,7 @@ mod tests {
                 for z in -radius..=radius {
                     let pos = BlockPos::of(x, y, z);
                     let block =
-                        ferrumc_utils::world::load_or_generate_chunk(state, pos.chunk(), DIMENSION)
+                        ferrumc_utils::world::load_or_generate_chunk(state, pos.chunk(), TEST_DIM_NAME)
                             .expect("load chunk")
                             .get_block(pos.chunk_block_pos());
                     out.push((x, y, z, block.raw()));
@@ -629,7 +708,7 @@ mod tests {
                 let pos = BlockPos::of(x, 64, z);
                 global
                     .world
-                    .set_block_and_fetch(pos, DIMENSION, fluid_block(FluidKind::Water, 1))
+                    .set_block_and_fetch(pos, TEST_DIM_NAME, fluid_block(FluidKind::Water, 1))
                     .expect("fill water");
                 positions.push(pos);
             }
@@ -637,19 +716,19 @@ mod tests {
         println!("batch size: {} positions", positions.len());
 
         // Warm the cache once so neither path pays generation cost during timing.
-        prewarm_chunks(global, &positions);
+        prewarm_chunks(global, TEST_DIM, &positions);
 
         let iterations = 20;
 
         let t0 = Instant::now();
         for _ in 0..iterations {
-            let _ = evaluate_serial(global, &positions);
+            let _ = evaluate_serial(global, TEST_DIM, &positions);
         }
         let serial = t0.elapsed() / iterations;
 
         let t1 = Instant::now();
         for _ in 0..iterations {
-            let _ = evaluate_parallel(global, &positions);
+            let _ = evaluate_parallel(global, TEST_DIM, &positions);
         }
         let parallel = t1.elapsed() / iterations;
 

--- a/src/bin/src/systems/fluids/mod.rs
+++ b/src/bin/src/systems/fluids/mod.rs
@@ -1,0 +1,663 @@
+//! Fluid simulation systems.
+//!
+//! This module wires the decoupled fluid-spreading algorithm in
+//! [`ferrumc_world::fluid::spread`] into the running server:
+//!
+//! 1. Block placements and breaks *seed* the scheduler with fluid ticks (see
+//!    [`seed_fluid_tick`] and its callers in the packet handlers).
+//! 2. Once per game tick, [`process_fluid_ticks`] drains the ticks due this tick, evaluates each
+//!    one against the live world, applies the resulting block changes, re-schedules affected
+//!    blocks, and broadcasts the changes to nearby players.
+//!
+//! The algorithm itself knows nothing about chunks, the ECS, or networking; this module provides
+//! the world-access glue ([`WorldBlockView`]) and side effects.
+
+use bevy_ecs::prelude::{Entity, Query, Res, ResMut, Resource};
+use bevy_ecs::prelude::MessageReader;
+use ferrumc_config::server_config::get_global_config;
+use ferrumc_core::tick::TickCounter;
+use ferrumc_core::transform::position::Position;
+use ferrumc_messages::BlockBrokenEvent;
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_net::packets::outgoing::block_update::BlockUpdate;
+use ferrumc_net_codec::net_types::network_position::NetworkPosition;
+use ferrumc_net_codec::net_types::var_int::VarInt;
+use ferrumc_state::{GlobalState, GlobalStateResource};
+use ferrumc_world::block_state_id::BlockStateId;
+use ferrumc_world::fluid::is_fluid;
+use ferrumc_world::fluid::spread::{compute_fluid_tick, BlockView, FluidChange};
+use ferrumc_world::fluid::fluid_state;
+use ferrumc_world::pos::BlockPos;
+use ferrumc_world::scheduler::{BlockTickScheduler, ScheduledTick, TickKind};
+use std::collections::HashMap;
+use tracing::{error, trace};
+
+/// Tick delay before a seeded or re-scheduled fluid block is evaluated.
+///
+/// Vanilla water updates every 5 ticks; lava is slower, but the simplified model uses a single
+/// delay for now. Kept here (rather than in the algorithm) because timing is a scheduling concern.
+pub const FLUID_TICK_DELAY: u64 = 5;
+
+/// Minimum number of due ticks in a batch before the parallel evaluation path is used.
+///
+/// Below this threshold the overhead of dispatching work to the thread pool outweighs the benefit,
+/// so the batch is evaluated serially on the calling thread. Small fluid disturbances (a single
+/// placed bucket) stay on the fast serial path; large flows fan out across cores.
+pub const PARALLEL_THRESHOLD: usize = 64;
+
+/// The dimension fluids are simulated in. The world currently only models the overworld; this
+/// constant marks the call sites that will need revisiting once multiple dimensions exist.
+const DIMENSION: &str = "overworld";
+
+/// ECS resource wrapping the per-chunk block tick scheduler.
+///
+/// The wrapper lives in the binary because the `ferrumc-world` crate intentionally does not depend
+/// on `bevy_ecs`; the scheduler itself is a plain data structure.
+#[derive(Resource, Default)]
+pub struct FluidScheduler(pub BlockTickScheduler);
+
+/// A [`BlockView`] backed by the live world.
+///
+/// Holds an owned [`GlobalState`] handle (an `Arc` clone) so it can be moved into worker threads
+/// during the parallel read phase. Reads go through the chunk cache via a shared (read) lock,
+/// which is safe to perform concurrently from multiple threads.
+struct WorldBlockView {
+    state: GlobalState,
+}
+
+impl BlockView for WorldBlockView {
+    fn block_at(&self, pos: BlockPos) -> BlockStateId {
+        match ferrumc_utils::world::load_or_generate_chunk(&self.state, pos.chunk(), DIMENSION) {
+            Ok(chunk) => chunk.get_block(pos.chunk_block_pos()),
+            Err(err) => {
+                // A failed chunk load is treated as air so the algorithm degrades gracefully
+                // rather than panicking inside the tick loop.
+                trace!("[fluid] failed to read block at {:?}: {}", pos.pos, err);
+                BlockStateId::default()
+            }
+        }
+    }
+}
+
+/// Schedules a fluid tick for `pos` if it currently contains fluid.
+///
+/// Intended to be called from block placement/break handlers (and from neighbour updates) to kick
+/// off or continue spreading. No-op for non-fluid blocks.
+pub fn seed_fluid_tick(
+    scheduler: &mut BlockTickScheduler,
+    state: &GlobalState,
+    current_tick: u64,
+    pos: BlockPos,
+) {
+    let block = match ferrumc_utils::world::load_or_generate_chunk(state, pos.chunk(), DIMENSION) {
+        Ok(chunk) => chunk.get_block(pos.chunk_block_pos()),
+        Err(_) => return,
+    };
+    if is_fluid(block) {
+        scheduler.schedule(pos, TickKind::FluidSpread, current_tick, FLUID_TICK_DELAY);
+    }
+}
+
+/// The six axis-aligned neighbours of a block position.
+fn neighbours(pos: BlockPos) -> [BlockPos; 6] {
+    [
+        pos + (0, 1, 0),
+        pos + (0, -1, 0),
+        pos + (1, 0, 0),
+        pos + (-1, 0, 0),
+        pos + (0, 0, 1),
+        pos + (0, 0, -1),
+    ]
+}
+
+/// Seeds fluid ticks around blocks that were broken this tick.
+///
+/// When a block is removed, any fluid bordering the now-empty space should re-evaluate so it can
+/// flow into the gap. Listens to [`BlockBrokenEvent`], which is emitted by both creative and
+/// survival break paths, so a single system covers both.
+pub fn seed_on_block_break(
+    mut events: MessageReader<BlockBrokenEvent>,
+    mut scheduler: ResMut<FluidScheduler>,
+    tick: Res<TickCounter>,
+    state: Res<GlobalStateResource>,
+) {
+    let current = tick.get();
+    for event in events.read() {
+        let pos = event.position;
+        // The broken position itself (in case it is now exposed to a fluid) and its neighbours.
+        seed_fluid_tick(&mut scheduler.0, &state.0, current, pos);
+        for neighbour in neighbours(pos) {
+            seed_fluid_tick(&mut scheduler.0, &state.0, current, neighbour);
+        }
+    }
+}
+
+/// Writes a single block change back to the world. Returns true on success.
+fn apply_change(state: &GlobalState, change: &FluidChange) -> bool {
+    match ferrumc_utils::world::load_or_generate_mut(state, change.pos.chunk(), DIMENSION) {
+        Ok(mut chunk) => {
+            chunk.set_block(change.pos.chunk_block_pos(), change.new_block);
+            true
+        }
+        Err(err) => {
+            error!(
+                "[fluid] failed to apply change at {:?}: {}",
+                change.pos.pos, err
+            );
+            false
+        }
+    }
+}
+
+/// Broadcasts a block change to every connected player within render distance of it.
+fn broadcast_change(
+    change: &FluidChange,
+    state: &GlobalState,
+    players: &Query<(Entity, &StreamWriter, &Position)>,
+) {
+    let render_distance = get_global_config().chunk_render_distance as i32;
+    let target_chunk = change.pos.chunk();
+    let packet = BlockUpdate {
+        location: NetworkPosition {
+            x: change.pos.pos.x,
+            y: change.pos.pos.y as i16,
+            z: change.pos.pos.z,
+        },
+        block_state_id: VarInt::from(change.new_block),
+    };
+
+    for (eid, conn, position) in players.iter() {
+        if !state.players.is_connected(eid) {
+            continue;
+        }
+        let player_chunk = position.chunk();
+        if (target_chunk.x() - player_chunk.x).abs() <= render_distance
+            && (target_chunk.z() - player_chunk.y).abs() <= render_distance
+        {
+            if let Err(err) = conn.send_packet_ref(&packet) {
+                trace!("[fluid] failed to send block update: {:?}", err);
+            }
+        }
+    }
+}
+
+/// Combines fluid changes that target the same block into a deterministic result.
+///
+/// Multiple due ticks in one batch can produce changes for the same position (for example two
+/// sources flowing into the same gap). To make the outcome independent of evaluation/thread order,
+/// changes are reduced per position by a fixed priority:
+///
+/// 1. Fluid of any level beats air/removal (a block being filled wins over being emptied).
+/// 2. Between two fluids, the stronger one wins (lower `level`).
+/// 3. Any remaining tie is broken by the raw block state id, which is stable.
+///
+/// `reschedule` is OR-ed across merged changes so a follow-up tick is kept if any contributor
+/// wanted one.
+fn reduce_changes(changes: Vec<FluidChange>) -> Vec<FluidChange> {
+    let mut by_pos: HashMap<BlockPos, FluidChange> = HashMap::new();
+    for change in changes {
+        by_pos
+            .entry(change.pos)
+            .and_modify(|existing| {
+                if change_priority(&change) > change_priority(existing) {
+                    let keep_reschedule = existing.reschedule || change.reschedule;
+                    *existing = change;
+                    existing.reschedule = keep_reschedule;
+                } else {
+                    existing.reschedule = existing.reschedule || change.reschedule;
+                }
+            })
+            .or_insert(change);
+    }
+    by_pos.into_values().collect()
+}
+
+/// Priority key for [`reduce_changes`]. Higher wins. Fluids outrank non-fluids; among fluids a
+/// lower level (stronger) outranks; ties fall back to the raw id for stability.
+fn change_priority(change: &FluidChange) -> (u8, i32, u32) {
+    match fluid_state(change.new_block) {
+        // Fluid: top tier (2). Stronger (lower level) should win, so negate the level.
+        Some(state) => (2, -(state.level as i32), change.new_block.raw()),
+        // Non-fluid (air/removal): lower tier (1).
+        None => (1, 0, change.new_block.raw()),
+    }
+}
+
+/// Evaluates a batch of due ticks against the world, returning the reduced set of changes.
+///
+/// When the batch is large enough the evaluation (a pure read over the world) is fanned out across
+/// the thread pool; otherwise it runs serially. Either way the result is identical because the read
+/// phase never mutates the world, so no tick observes another tick's changes within the batch.
+fn evaluate_batch(state: &GlobalState, due: &[(ferrumc_world::pos::ChunkPos, Vec<ScheduledTick>)]) -> Vec<FluidChange> {
+    // Flatten the per-chunk groups into a single list of positions to evaluate.
+    let positions: Vec<BlockPos> = due
+        .iter()
+        .flat_map(|(_, ticks)| ticks.iter().map(|t| t.pos))
+        .collect();
+
+    if positions.len() < PARALLEL_THRESHOLD {
+        evaluate_serial(state, &positions)
+    } else {
+        evaluate_parallel(state, &positions)
+    }
+}
+
+/// Serial evaluation: computes changes for every position on the calling thread.
+fn evaluate_serial(state: &GlobalState, positions: &[BlockPos]) -> Vec<FluidChange> {
+    let view = WorldBlockView {
+        state: state.clone(),
+    };
+    let mut changes = Vec::new();
+    for &pos in positions {
+        changes.extend(compute_fluid_tick(pos, &view));
+    }
+    reduce_changes(changes)
+}
+
+/// Parallel evaluation: splits the positions across the thread pool and merges the results.
+///
+/// Each task gets its own `Arc` handle and its own read-only [`WorldBlockView`]. Because the world
+/// is never written during evaluation, concurrent reads are safe and the merged result is
+/// independent of task scheduling order (after [`reduce_changes`] applies its deterministic
+/// tie-breaking).
+///
+/// Before fanning out, every chunk that the batch could read (each ticking block's chunk and its
+/// six neighbours' chunks) is loaded/generated **serially on the calling thread**. This is
+/// essential: `load_or_generate_chunk` writes to the chunk cache and storage backend when a chunk
+/// is missing, which is not safe to do concurrently (it would contend on the LMDB writer and the
+/// DashMap shard). Pre-warming guarantees the parallel phase only ever hits cached chunks, making
+/// it a genuine read-only phase.
+fn evaluate_parallel(state: &GlobalState, positions: &[BlockPos]) -> Vec<FluidChange> {
+    prewarm_chunks(state, positions);
+
+    let worker_count = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let task_size = positions.len().div_ceil(worker_count).max(1);
+    let mut batch = state.thread_pool.batch::<Vec<FluidChange>>();
+    for slice in positions.chunks(task_size) {
+        let slice = slice.to_vec();
+        let task_state = state.clone();
+        batch.execute(move || {
+            let view = WorldBlockView { state: task_state };
+            let mut changes = Vec::new();
+            for pos in slice {
+                changes.extend(compute_fluid_tick(pos, &view));
+            }
+            changes
+        });
+    }
+
+    let mut all = Vec::new();
+    for partial in batch.wait() {
+        all.extend(partial);
+    }
+    reduce_changes(all)
+}
+
+/// Loads or generates, on the calling thread, every chunk the parallel evaluation phase might read.
+///
+/// A fluid tick reads the ticking block and its six axis-aligned neighbours, so the set of chunks
+/// touched is each position's chunk plus the chunks of its neighbours. Doing this serially up front
+/// removes all chunk generation/insertion from the parallel phase, leaving only cache reads there.
+fn prewarm_chunks(state: &GlobalState, positions: &[BlockPos]) {
+    use std::collections::HashSet;
+    let mut chunks = HashSet::new();
+    for &pos in positions {
+        chunks.insert(pos.chunk());
+        for neighbour in neighbours(pos) {
+            chunks.insert(neighbour.chunk());
+        }
+    }
+    for chunk_pos in chunks {
+        // The result is intentionally discarded; the call's side effect (populating the cache) is
+        // what matters. Errors are ignored here and surfaced later when the block is read.
+        let _ = ferrumc_utils::world::load_or_generate_chunk(state, chunk_pos, DIMENSION);
+    }
+}
+
+/// Applies reduced changes to the world, broadcasts them, and re-schedules follow-up ticks.
+///
+/// Shared by the serial and parallel processing paths so both behave identically once changes have
+/// been computed. Runs on the calling (main) thread, so writes are serial and need no locking
+/// beyond the per-chunk guard taken inside [`apply_change`].
+fn apply_changes(
+    changes: &[FluidChange],
+    scheduler: &mut BlockTickScheduler,
+    state: &GlobalState,
+    current: u64,
+    players: &Query<(Entity, &StreamWriter, &Position)>,
+) {
+    for change in changes {
+        if !apply_change(state, change) {
+            continue;
+        }
+        broadcast_change(change, state, players);
+        if change.reschedule {
+            scheduler.schedule(change.pos, TickKind::FluidSpread, current, FLUID_TICK_DELAY);
+        }
+    }
+}
+
+/// Processes all fluid ticks due this game tick.
+///
+/// The read/evaluate phase ([`evaluate_batch`]) may run in parallel; the apply phase
+/// ([`apply_changes`]) is serial on the main thread. Because evaluation is purely read-only, the
+/// world state observed by every tick in the batch is the same snapshot, making the parallel result
+/// identical to the serial one (verified by the parity test).
+pub fn process_fluid_ticks(
+    mut scheduler: ResMut<FluidScheduler>,
+    tick: Res<TickCounter>,
+    state: Res<GlobalStateResource>,
+    players: Query<(Entity, &StreamWriter, &Position)>,
+) {
+    let current = tick.get();
+    let due = scheduler.0.drain_due(current);
+    if due.is_empty() {
+        return;
+    }
+
+    let global = &state.0;
+    let changes = evaluate_batch(global, &due);
+    if changes.is_empty() {
+        return;
+    }
+
+    trace!(
+        "[fluid] tick {}: {} scheduled tick(s) produced {} change(s)",
+        current,
+        due.iter().map(|(_, t)| t.len()).sum::<usize>(),
+        changes.len(),
+    );
+
+    apply_changes(&changes, &mut scheduler.0, global, current, &players);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::prelude::{Schedule, World};
+    use ferrumc_macros::block;
+    use ferrumc_state::create_test_state;
+    use ferrumc_world::fluid::{fluid_block, fluid_state, FluidKind};
+    use ferrumc_world::pos::BlockPos;
+
+    /// Drives the fluid system end-to-end through the ECS, mirroring the real tick schedule
+    /// (advance tick counter, then process fluid ticks). Verifies that a seeded water source
+    /// actually spreads into the live world without a player present.
+    #[test]
+    fn seeded_water_source_spreads_through_ecs() {
+        let mut world = World::new();
+        let (state, _temp_dir) = create_test_state();
+
+        // Lay a stone floor under the source so water spreads horizontally instead of only falling.
+        {
+            let global = &state.0;
+            let source = BlockPos::of(0, 64, 0);
+            for x in -4..=4 {
+                for z in -4..=4 {
+                    let mut chunk = ferrumc_utils::world::load_or_generate_mut(
+                        global,
+                        BlockPos::of(x, 63, z).chunk(),
+                        DIMENSION,
+                    )
+                    .expect("load chunk");
+                    chunk.set_block(BlockPos::of(x, 63, z).chunk_block_pos(), block!("stone"));
+                }
+            }
+            // Place the water source.
+            let mut chunk =
+                ferrumc_utils::world::load_or_generate_mut(global, source.chunk(), DIMENSION)
+                    .expect("load chunk");
+            chunk.set_block(source.chunk_block_pos(), fluid_block(FluidKind::Water, 0));
+        }
+
+        world.insert_resource(state.clone());
+        world.insert_resource(TickCounter::new());
+        let mut sched = FluidScheduler::default();
+
+        // Seed the source as the placement handler would.
+        let source = BlockPos::of(0, 64, 0);
+        seed_fluid_tick(&mut sched.0, &state.0, 0, source);
+        world.insert_resource(sched);
+
+        // Build a schedule that mimics the tick: advance counter, then process fluids.
+        let mut schedule = Schedule::default();
+        schedule.add_systems(crate::systems::tick_counter::handle);
+        schedule.add_systems(process_fluid_ticks);
+
+        // Run enough ticks for the source to spread to its neighbours (delay is 5 ticks).
+        for _ in 0..30 {
+            schedule.run(&mut world);
+        }
+
+        // Verify a horizontal neighbour now holds flowing water in the live world.
+        let neighbour = BlockPos::of(1, 64, 0);
+        let block = ferrumc_utils::world::load_or_generate_chunk(&state.0, neighbour.chunk(), DIMENSION)
+            .expect("load chunk")
+            .get_block(neighbour.chunk_block_pos());
+        let fluid = fluid_state(block).expect("neighbour should contain water after spreading");
+        assert_eq!(fluid.kind, FluidKind::Water);
+        assert!(!fluid.is_source(), "spread block should be flowing, not a source");
+    }
+
+    /// Whether to force the serial or parallel evaluator in [`run_to_steady_state`].
+    #[derive(Clone, Copy)]
+    enum EvalMode {
+        Serial,
+        Parallel,
+    }
+
+    /// Drives the full fluid loop (drain → evaluate → apply → re-schedule) directly, without the
+    /// ECS, using the chosen evaluator. Returns once the scheduler empties or `max_ticks` elapse.
+    fn run_to_steady_state(
+        state: &GlobalState,
+        scheduler: &mut BlockTickScheduler,
+        mode: EvalMode,
+        max_ticks: u64,
+    ) {
+        for tick in 1..=max_ticks {
+            let due = scheduler.drain_due(tick);
+            if due.is_empty() {
+                if scheduler.pending_count() == 0 {
+                    break;
+                }
+                continue;
+            }
+            let positions: Vec<BlockPos> = due
+                .iter()
+                .flat_map(|(_, ticks)| ticks.iter().map(|t| t.pos))
+                .collect();
+            let changes = match mode {
+                EvalMode::Serial => evaluate_serial(state, &positions),
+                EvalMode::Parallel => evaluate_parallel(state, &positions),
+            };
+            for change in &changes {
+                apply_change(state, change);
+                if change.reschedule {
+                    scheduler.schedule(change.pos, TickKind::FluidSpread, tick, FLUID_TICK_DELAY);
+                }
+            }
+        }
+    }
+
+    /// Builds a fresh world with a stone floor and walls forming an enclosed basin, plus a water
+    /// source at the centre, and seeds the source. Returns the state, a temp dir guard, and the
+    /// seeded scheduler.
+    fn basin_world(radius: i32) -> (GlobalStateResource, tempfile::TempDir, BlockTickScheduler) {
+        let (state, temp_dir) = create_test_state();
+        {
+            let global = &state.0;
+            // Pre-generate every chunk this basin spans (each call acquires and releases its own
+            // guard), so the subsequent writes hit cached chunks. A fresh test world has no chunks
+            // stored, so set_block_and_fetch alone would fail with ChunkNotFound.
+            let mut seen = std::collections::HashSet::new();
+            for x in -radius..=radius {
+                for z in -radius..=radius {
+                    let chunk_pos = BlockPos::of(x, 64, z).chunk();
+                    if seen.insert((chunk_pos.x(), chunk_pos.z())) {
+                        let _ = ferrumc_utils::world::load_or_generate_chunk(
+                            global, chunk_pos, DIMENSION,
+                        )
+                        .expect("generate chunk");
+                    }
+                }
+            }
+            // Use set_block_and_fetch so each write acquires and releases its own chunk guard.
+            // Holding one chunk guard while loading another position in the *same* chunk (e.g. the
+            // floor at y=63 and the wall at y=64 share a chunk) would re-enter the DashMap shard
+            // lock and deadlock.
+            for x in -radius..=radius {
+                for z in -radius..=radius {
+                    global
+                        .world
+                        .set_block_and_fetch(BlockPos::of(x, 63, z), DIMENSION, block!("stone"))
+                        .expect("set floor");
+                    if x.abs() == radius || z.abs() == radius {
+                        global
+                            .world
+                            .set_block_and_fetch(BlockPos::of(x, 64, z), DIMENSION, block!("stone"))
+                            .expect("set wall");
+                    }
+                }
+            }
+            global
+                .world
+                .set_block_and_fetch(
+                    BlockPos::of(0, 64, 0),
+                    DIMENSION,
+                    fluid_block(FluidKind::Water, 0),
+                )
+                .expect("set source");
+        }
+        let mut scheduler = BlockTickScheduler::new();
+        seed_fluid_tick(&mut scheduler, &state.0, 0, BlockPos::of(0, 64, 0));
+        (state, temp_dir, scheduler)
+    }
+
+    /// Snapshots the block states across a cuboid so two worlds can be compared exactly.
+    fn snapshot(state: &GlobalState, radius: i32, y_lo: i32, y_hi: i32) -> Vec<(i32, i32, i32, u32)> {
+        let mut out = Vec::new();
+        for x in -radius..=radius {
+            for y in y_lo..=y_hi {
+                for z in -radius..=radius {
+                    let pos = BlockPos::of(x, y, z);
+                    let block =
+                        ferrumc_utils::world::load_or_generate_chunk(state, pos.chunk(), DIMENSION)
+                            .expect("load chunk")
+                            .get_block(pos.chunk_block_pos());
+                    out.push((x, y, z, block.raw()));
+                }
+            }
+        }
+        out
+    }
+
+    /// The serial and parallel evaluators must converge to the exact same world state. This is the
+    /// core guarantee that parallelisation does not change observable behaviour.
+    #[test]
+    fn serial_and_parallel_reach_identical_state() {
+        let radius = 3;
+
+        let (serial_state, _s_tmp, mut serial_sched) = basin_world(radius);
+        run_to_steady_state(&serial_state.0, &mut serial_sched, EvalMode::Serial, 400);
+
+        let (par_state, _p_tmp, mut par_sched) = basin_world(radius);
+        run_to_steady_state(&par_state.0, &mut par_sched, EvalMode::Parallel, 400);
+
+        let serial_snap = snapshot(&serial_state.0, radius, 62, 66);
+        let par_snap = snapshot(&par_state.0, radius, 62, 66);
+        assert_eq!(
+            serial_snap, par_snap,
+            "serial and parallel fluid evaluation must produce identical world state"
+        );
+    }
+
+    /// `reduce_changes` must be deterministic: the same set of conflicting changes always collapses
+    /// to the same winner regardless of input order.
+    #[test]
+    fn reduce_changes_is_order_independent() {
+        let pos = BlockPos::of(5, 70, 5);
+        let strong = FluidChange {
+            pos,
+            new_block: fluid_block(FluidKind::Water, 1),
+            reschedule: true,
+        };
+        let weak = FluidChange {
+            pos,
+            new_block: fluid_block(FluidKind::Water, 6),
+            reschedule: false,
+        };
+        let air = FluidChange {
+            pos,
+            new_block: block!("air"),
+            reschedule: false,
+        };
+
+        let a = reduce_changes(vec![strong, weak, air]);
+        let b = reduce_changes(vec![air, weak, strong]);
+        let c = reduce_changes(vec![weak, air, strong]);
+
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        assert_eq!(c.len(), 1);
+        // The strongest (lowest level) fluid wins in every ordering.
+        assert_eq!(a[0].new_block, strong.new_block);
+        assert_eq!(b[0].new_block, strong.new_block);
+        assert_eq!(c[0].new_block, strong.new_block);
+        // reschedule is OR-ed across contributors.
+        assert!(a[0].reschedule);
+    }
+
+    /// Manual benchmark comparing serial vs parallel evaluation on a large batch. Ignored by
+    /// default (it only prints timing data and is sensitive to machine load); run explicitly with:
+    /// `cargo test -p ferrumc --bin ferrumc bench_serial_vs_parallel -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "benchmark; prints timing only"]
+    fn bench_serial_vs_parallel() {
+        use std::time::Instant;
+
+        // Large flat floor so a big batch of fluid positions can be evaluated at once.
+        let radius = 48;
+        let (state, _tmp, _sched) = basin_world(radius);
+        let global = &state.0;
+
+        // Fill the interior with flowing water states to create a large evaluation batch.
+        let mut positions = Vec::new();
+        for x in -(radius - 1)..=(radius - 1) {
+            for z in -(radius - 1)..=(radius - 1) {
+                let pos = BlockPos::of(x, 64, z);
+                global
+                    .world
+                    .set_block_and_fetch(pos, DIMENSION, fluid_block(FluidKind::Water, 1))
+                    .expect("fill water");
+                positions.push(pos);
+            }
+        }
+        println!("batch size: {} positions", positions.len());
+
+        // Warm the cache once so neither path pays generation cost during timing.
+        prewarm_chunks(global, &positions);
+
+        let iterations = 20;
+
+        let t0 = Instant::now();
+        for _ in 0..iterations {
+            let _ = evaluate_serial(global, &positions);
+        }
+        let serial = t0.elapsed() / iterations;
+
+        let t1 = Instant::now();
+        for _ in 0..iterations {
+            let _ = evaluate_parallel(global, &positions);
+        }
+        let parallel = t1.elapsed() / iterations;
+
+        println!("serial avg:   {:?}", serial);
+        println!("parallel avg: {:?}", parallel);
+        println!(
+            "speedup: {:.2}x",
+            serial.as_secs_f64() / parallel.as_secs_f64()
+        );
+    }
+}

--- a/src/bin/src/systems/mod.rs
+++ b/src/bin/src/systems/mod.rs
@@ -5,6 +5,7 @@ pub mod chunk_unloader;
 pub mod connection_killer;
 pub mod day_cycle;
 pub mod emit_player_joined;
+pub mod fluids;
 pub mod keep_alive_system;
 pub mod lan_pinger;
 pub mod listeners;
@@ -16,6 +17,7 @@ pub mod physics;
 mod player_swimming;
 mod send_entity_updates;
 pub mod shutdown_systems;
+pub mod tick_counter;
 pub(crate) mod update_player_ping;
 pub mod world_sync;
 
@@ -33,6 +35,10 @@ pub fn register_game_systems(schedule: &mut bevy_ecs::schedule::Schedule) {
     );
     schedule.add_systems(mq::process);
     schedule.add_systems(player_swimming::detect_player_swimming);
+
+    // Process scheduled fluid ticks: evaluate spreading, apply, broadcast, re-schedule.
+    schedule.add_systems(fluids::seed_on_block_break);
+    schedule.add_systems(fluids::process_fluid_ticks);
 
     schedule.add_systems(send_entity_updates::handle);
 

--- a/src/bin/src/systems/tick_counter.rs
+++ b/src/bin/src/systems/tick_counter.rs
@@ -1,0 +1,12 @@
+use bevy_ecs::prelude::ResMut;
+use ferrumc_core::tick::TickCounter;
+
+/// Advances the global [`TickCounter`] by one.
+///
+/// Registered as the first system in the tick schedule so that every other
+/// system running in the same tick observes a consistent, already-incremented
+/// tick number. This is the authoritative clock for scheduled work such as
+/// fluid spreading.
+pub fn handle(mut tick: ResMut<TickCounter>) {
+    tick.advance();
+}

--- a/src/lib/core/src/lib.rs
+++ b/src/lib/core/src/lib.rs
@@ -8,5 +8,6 @@ pub mod conn;
 pub mod identity;
 pub mod mq;
 pub mod state;
+pub mod tick;
 pub mod time;
 pub mod transform;

--- a/src/lib/core/src/tick.rs
+++ b/src/lib/core/src/tick.rs
@@ -1,0 +1,49 @@
+use bevy_ecs::prelude::Resource;
+
+/// Monotonic game tick counter.
+///
+/// Incremented once per game tick (see the tick schedule in the binary's game loop).
+/// Unlike [`crate::time::WorldTime`], which wraps every Minecraft day, this value never
+/// resets for the lifetime of the server process. It is the authoritative clock for any
+/// system that needs to schedule work a fixed number of ticks into the future, such as
+/// fluid spreading or other scheduled block updates.
+#[derive(Resource, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TickCounter(u64);
+
+impl TickCounter {
+    /// Creates a new counter starting at tick zero.
+    pub const fn new() -> Self {
+        Self(0)
+    }
+
+    /// Advances the counter by one tick. Called once per game tick.
+    #[inline]
+    pub fn advance(&mut self) {
+        self.0 = self.0.wrapping_add(1);
+    }
+
+    /// Returns the current tick number.
+    #[inline]
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_at_zero() {
+        let counter = TickCounter::new();
+        assert_eq!(counter.get(), 0);
+    }
+
+    #[test]
+    fn advance_increments() {
+        let mut counter = TickCounter::new();
+        counter.advance();
+        counter.advance();
+        assert_eq!(counter.get(), 2);
+    }
+}

--- a/src/lib/utils/threadpool/src/lib.rs
+++ b/src/lib/utils/threadpool/src/lib.rs
@@ -3,6 +3,7 @@ use std::cmp::max;
 use std::sync::Arc;
 use std::time::Duration;
 
+
 /// A thread pool for managing and executing tasks concurrently.
 pub struct ThreadPool {
     pool: Arc<rusty_pool::ThreadPool>,

--- a/src/lib/world/src/chunk/section/direct.rs
+++ b/src/lib/world/src/chunk/section/direct.rs
@@ -42,6 +42,25 @@ impl DirectSection {
     pub fn block_count(&self) -> u16 {
         self.1
     }
+
+    /// Packs every block id into the chunk-packet "data array" layout: a stream of u64s with
+    /// 16-bit entries, lowest index in the low bits, no spillover across longs.
+    ///
+    /// `bits_per_entry` is fixed at 16 for direct sections (we ship the global palette id), so
+    /// exactly four entries fit in each long. We could in theory `bytemuck::cast_slice::<u16,
+    /// u64>` the inner buffer, but that would assume a specific host endianness; the explicit
+    /// shift below is portable and not on a hot path (chunk send, not per-tick).
+    pub fn to_network_longs(&self) -> Vec<u64> {
+        const ENTRIES_PER_LONG: usize = 4;
+        const BITS_PER_ENTRY: usize = 16;
+        let mut out = vec![0u64; CHUNK_SECTION_LENGTH / ENTRIES_PER_LONG];
+        for (i, &id) in self.0.iter().enumerate() {
+            let long_idx = i / ENTRIES_PER_LONG;
+            let bit_idx = (i % ENTRIES_PER_LONG) * BITS_PER_ENTRY;
+            out[long_idx] |= (id as u64) << bit_idx;
+        }
+        out
+    }
 }
 
 impl From<&mut UniformSection> for DirectSection {
@@ -69,5 +88,49 @@ impl From<&mut PalettedSection> for DirectSection {
         }
 
         Self(vec.into_boxed_slice(), count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip: every block id we put into a DirectSection must be recoverable from the packed
+    /// network long array. This guards against the previous bug where the data_array was sent
+    /// empty, causing every block to decode as 0 client-side (lava rendering as water etc.).
+    #[test]
+    fn to_network_longs_round_trips() {
+        let mut section = DirectSection::default();
+        // A handful of ids spread across the 4096 cells, including the boundaries between longs.
+        let samples: &[(usize, u32)] = &[
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),       // first long
+            (4, 100),     // second long, low entry
+            (7, 0xFFFF),  // second long, high entry (max representable)
+            (4095, 7),    // last cell
+        ];
+        for &(idx, id) in samples {
+            section.set_block(idx, BlockStateId::new(id));
+        }
+
+        let longs = section.to_network_longs();
+        assert_eq!(longs.len(), CHUNK_SECTION_LENGTH / 4);
+
+        // Manually decode each long (4 entries of 16 bits, lowest index in the low bits) and
+        // compare against the section's stored ids.
+        for long_idx in 0..longs.len() {
+            for entry in 0..4 {
+                let block_idx = long_idx * 4 + entry;
+                let decoded = ((longs[long_idx] >> (entry * 16)) & 0xFFFF) as u32;
+                assert_eq!(
+                    decoded,
+                    section.get_block(block_idx).raw(),
+                    "mismatch at block_idx {}",
+                    block_idx
+                );
+            }
+        }
     }
 }

--- a/src/lib/world/src/chunk/section/network.rs
+++ b/src/lib/world/src/chunk/section/network.rs
@@ -88,11 +88,14 @@ impl<'section> From<&'section PalettedSection> for PalettedContainer<'section> {
 }
 
 impl<'section> From<&'section DirectSection> for PalettedContainer<'section> {
-    fn from(_section: &'section DirectSection) -> Self {
+    fn from(section: &'section DirectSection) -> Self {
+        // Direct sections carry one global-palette id per block. Without a real data_array the
+        // client decoded every block as 0, which is what made e.g. lava sections render with
+        // water's texture on the initial chunk send.
         PalettedContainer {
             bits_per_entry: 16,
             palette: NetworkPalette::Direct {},
-            data_array: NetworkArray::new_owned(vec![]), // TODO: fix this to use the data from the section; bytemuck::cast_slice(&section.0)
+            data_array: NetworkArray::new_owned(section.to_network_longs()),
         }
     }
 }

--- a/src/lib/world/src/dimension.rs
+++ b/src/lib/world/src/dimension.rs
@@ -1,0 +1,78 @@
+//! Logical dimensions exposed to gameplay systems.
+//!
+//! The chunk store and database layer key everything by a free-form `&str` (`"overworld"`,
+//! `"the_nether"`, ...) and that is intentionally not changing here: those layers only need a
+//! stable identifier and never need to branch on which dimension is which. Gameplay systems
+//! (fluids, weather, mob spawning, ...) on the other hand do need to make per-dimension
+//! decisions, and a stringly-typed value at every match site is fragile.
+//!
+//! [`Dimension`] is the small typed projection the gameplay side uses. It converts to/from the
+//! string form via [`Dimension::as_str`] / [`Dimension::from_str`] when crossing into the storage
+//! layer. New dimensions added to the world should be added here so the compiler points out the
+//! match sites that need to learn about them.
+
+/// The vanilla dimensions. Custom dimensions are not modelled yet; if a chunk's dimension
+/// string is unrecognised, callers receive `None` from [`Dimension::from_str`] and should fall
+/// back to overworld behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Dimension {
+    Overworld,
+    Nether,
+    End,
+}
+
+impl Dimension {
+    /// Returns the canonical string identifier used by the chunk store and network protocol.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Dimension::Overworld => "overworld",
+            Dimension::Nether => "the_nether",
+            Dimension::End => "the_end",
+        }
+    }
+
+    /// Parses a dimension identifier as it appears in chunk metadata or registry packets.
+    ///
+    /// Accepts both the bare form (`"overworld"`) and the namespaced form
+    /// (`"minecraft:overworld"`) so callers do not need to strip the namespace themselves.
+    pub fn from_str(s: &str) -> Option<Self> {
+        let bare = s.strip_prefix("minecraft:").unwrap_or(s);
+        match bare {
+            "overworld" => Some(Self::Overworld),
+            "the_nether" | "nether" => Some(Self::Nether),
+            "the_end" | "end" => Some(Self::End),
+            _ => None,
+        }
+    }
+}
+
+impl Default for Dimension {
+    fn default() -> Self {
+        Dimension::Overworld
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_known_dimensions() {
+        for dim in [Dimension::Overworld, Dimension::Nether, Dimension::End] {
+            assert_eq!(Dimension::from_str(dim.as_str()), Some(dim));
+        }
+    }
+
+    #[test]
+    fn accepts_namespaced_form() {
+        assert_eq!(
+            Dimension::from_str("minecraft:the_nether"),
+            Some(Dimension::Nether)
+        );
+    }
+
+    #[test]
+    fn unknown_dimension_is_none() {
+        assert_eq!(Dimension::from_str("custom:moon"), None);
+    }
+}

--- a/src/lib/world/src/fluid/mod.rs
+++ b/src/lib/world/src/fluid/mod.rs
@@ -13,6 +13,7 @@
 //! to revise later.
 
 use crate::block_state_id::{BlockStateId, ID2BLOCK};
+use crate::dimension::Dimension;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 
@@ -38,6 +39,53 @@ impl FluidKind {
         match self {
             FluidKind::Water => "minecraft:water",
             FluidKind::Lava => "minecraft:lava",
+        }
+    }
+}
+
+/// Per-fluid, per-dimension behaviour parameters.
+///
+/// Vanilla differentiates water and lava on two axes (how fast they tick, how far they spread)
+/// and lava additionally behaves differently in the Nether (faster + further). Encoding this as
+/// a small struct keeps the spreading algorithm dimension-agnostic: callers look up the rules
+/// once with [`FluidRules::for_kind`] and pass the struct in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FluidRules {
+    /// How much the fluid `level` increases for each horizontal step away from a source.
+    /// Vanilla water = 1 (spreads 7 blocks), overworld lava = 2 (spreads 3 blocks),
+    /// Nether lava = 1 (spreads 7 blocks).
+    pub level_step: u8,
+    /// Maximum `level` that still spreads horizontally. A flowing block at `level >
+    /// max_spread_level` stops spreading. Combined with `level_step`, this defines the maximum
+    /// reach: `floor(max_spread_level / level_step)` blocks from a source on flat ground.
+    pub max_spread_level: u8,
+    /// Number of game ticks between scheduled updates of a flowing block of this fluid.
+    /// Vanilla water = 5, overworld lava = 30, Nether lava = 10.
+    pub tick_delay: u64,
+}
+
+impl FluidRules {
+    /// Returns the rules vanilla uses for `(kind, dimension)`.
+    ///
+    /// `Dimension::End` falls back to overworld parameters because vanilla treats the End the
+    /// same as the overworld for fluid behaviour.
+    pub const fn for_kind(kind: FluidKind, dimension: Dimension) -> Self {
+        match (kind, dimension) {
+            (FluidKind::Water, _) => Self {
+                level_step: 1,
+                max_spread_level: 7,
+                tick_delay: 5,
+            },
+            (FluidKind::Lava, Dimension::Nether) => Self {
+                level_step: 1,
+                max_spread_level: 7,
+                tick_delay: 10,
+            },
+            (FluidKind::Lava, Dimension::Overworld | Dimension::End) => Self {
+                level_step: 2,
+                max_spread_level: 7,
+                tick_delay: 30,
+            },
         }
     }
 }

--- a/src/lib/world/src/fluid/mod.rs
+++ b/src/lib/world/src/fluid/mod.rs
@@ -1,0 +1,204 @@
+//! Runtime fluid property lookups.
+//!
+//! The [`crate::block_state_id::BlockStateId`] type stores blocks as flat protocol IDs, which is
+//! efficient but opaque: it carries no information about whether a given state is a fluid or what
+//! its level is. The [`block!`](ferrumc_macros::block) macro can resolve names and properties, but
+//! only at compile time. Fluid spreading needs to inspect and construct fluid states at runtime
+//! (reading a block's level, producing the next-lower level, etc.), so this module precomputes a
+//! pair of small lookup tables at startup.
+//!
+//! The tables are intentionally the only place that knows how fluid states map to IDs. Fluid
+//! spreading logic depends on the [`FluidKind`] / level abstraction exposed here rather than on
+//! raw block IDs, which keeps the spreading algorithm decoupled from the block registry and easy
+//! to revise later.
+
+use crate::block_state_id::{BlockStateId, ID2BLOCK};
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+pub mod spread;
+
+#[cfg(test)]
+mod tests_integration;
+
+/// The category of a fluid.
+///
+/// Water and lava share the same spreading machinery but differ in their parameters (spread
+/// distance, tick delay). Keeping them as a small enum lets the spreading algorithm branch on
+/// behaviour without hard-coding block IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FluidKind {
+    Water,
+    Lava,
+}
+
+impl FluidKind {
+    /// The Minecraft block name backing this fluid.
+    const fn block_name(self) -> &'static str {
+        match self {
+            FluidKind::Water => "minecraft:water",
+            FluidKind::Lava => "minecraft:lava",
+        }
+    }
+}
+
+/// The maximum `level` property value a fluid state can have (inclusive). Vanilla fluids use
+/// levels 0..=15, where 0 is the source/full block.
+pub const MAX_FLUID_LEVEL: u8 = 15;
+
+/// A decoded fluid state: which fluid it is and its `level` property.
+///
+/// In Minecraft's data model, `level` 0 is a source (full) block and increasing values are
+/// progressively shallower flowing fluid. (Levels 8..=15 are the "falling" variants in vanilla;
+/// the simplified spreading model does not yet distinguish them, but the raw level is preserved
+/// here so a future revision can.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FluidState {
+    pub kind: FluidKind,
+    pub level: u8,
+}
+
+impl FluidState {
+    /// Returns true if this is a source block (level 0).
+    #[inline]
+    pub fn is_source(&self) -> bool {
+        self.level == 0
+    }
+}
+
+struct FluidTables {
+    /// Maps a block state ID to its decoded fluid state, for every fluid block state.
+    id_to_fluid: HashMap<u32, FluidState>,
+    /// Maps `(kind, level)` to the corresponding block state ID. Indexed as
+    /// `level_to_id[kind][level]`.
+    water_levels: [BlockStateId; (MAX_FLUID_LEVEL as usize) + 1],
+    lava_levels: [BlockStateId; (MAX_FLUID_LEVEL as usize) + 1],
+}
+
+impl FluidTables {
+    fn build() -> Self {
+        let mut id_to_fluid = HashMap::new();
+        let mut water_levels = [BlockStateId::default(); (MAX_FLUID_LEVEL as usize) + 1];
+        let mut lava_levels = [BlockStateId::default(); (MAX_FLUID_LEVEL as usize) + 1];
+
+        for kind in [FluidKind::Water, FluidKind::Lava] {
+            let name = kind.block_name();
+            let levels = match kind {
+                FluidKind::Water => &mut water_levels,
+                FluidKind::Lava => &mut lava_levels,
+            };
+
+            for (id, block) in ID2BLOCK.iter().enumerate() {
+                if block.name != name {
+                    continue;
+                }
+                let level = block
+                    .properties
+                    .as_ref()
+                    .and_then(|props| props.get("level"))
+                    .and_then(|lvl| lvl.parse::<u8>().ok());
+
+                let Some(level) = level else {
+                    continue;
+                };
+                if level > MAX_FLUID_LEVEL {
+                    continue;
+                }
+
+                let state_id = BlockStateId::new(id as u32);
+                levels[level as usize] = state_id;
+                id_to_fluid.insert(id as u32, FluidState { kind, level });
+            }
+        }
+
+        FluidTables {
+            id_to_fluid,
+            water_levels,
+            lava_levels,
+        }
+    }
+
+    #[inline]
+    fn levels_for(&self, kind: FluidKind) -> &[BlockStateId; (MAX_FLUID_LEVEL as usize) + 1] {
+        match kind {
+            FluidKind::Water => &self.water_levels,
+            FluidKind::Lava => &self.lava_levels,
+        }
+    }
+}
+
+lazy_static! {
+    static ref FLUID_TABLES: FluidTables = FluidTables::build();
+}
+
+/// Returns the [`FluidState`] for a block, or `None` if the block is not a fluid.
+#[inline]
+pub fn fluid_state(block: BlockStateId) -> Option<FluidState> {
+    FLUID_TABLES.id_to_fluid.get(&block.raw()).copied()
+}
+
+/// Returns true if the block is any fluid (water or lava, at any level).
+#[inline]
+pub fn is_fluid(block: BlockStateId) -> bool {
+    FLUID_TABLES.id_to_fluid.contains_key(&block.raw())
+}
+
+/// Returns the block state ID for the given fluid kind and level.
+///
+/// `level` is clamped to the valid range `0..=MAX_FLUID_LEVEL`.
+#[inline]
+pub fn fluid_block(kind: FluidKind, level: u8) -> BlockStateId {
+    let level = level.min(MAX_FLUID_LEVEL);
+    FLUID_TABLES.levels_for(kind)[level as usize]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrumc_macros::block;
+
+    #[test]
+    fn water_source_round_trips() {
+        let source = fluid_block(FluidKind::Water, 0);
+        assert_eq!(source, block!("water", { level: 0 }));
+
+        let state = fluid_state(source).expect("water source should be a fluid");
+        assert_eq!(state.kind, FluidKind::Water);
+        assert_eq!(state.level, 0);
+        assert!(state.is_source());
+    }
+
+    #[test]
+    fn lava_levels_resolve() {
+        for level in 0..=MAX_FLUID_LEVEL {
+            let id = fluid_block(FluidKind::Lava, level);
+            let state = fluid_state(id).expect("lava state should be a fluid");
+            assert_eq!(state.kind, FluidKind::Lava);
+            assert_eq!(state.level, level);
+        }
+    }
+
+    #[test]
+    fn non_fluid_is_none() {
+        assert!(fluid_state(block!("stone")).is_none());
+        assert!(!is_fluid(block!("stone")));
+        assert!(!is_fluid(block!("air")));
+    }
+
+    #[test]
+    fn water_and_lava_are_distinct() {
+        let water = fluid_block(FluidKind::Water, 0);
+        let lava = fluid_block(FluidKind::Lava, 0);
+        assert_ne!(water, lava);
+        assert!(is_fluid(water));
+        assert!(is_fluid(lava));
+    }
+
+    #[test]
+    fn level_is_clamped() {
+        // Out-of-range levels clamp to the max rather than panicking.
+        let clamped = fluid_block(FluidKind::Water, 200);
+        let max = fluid_block(FluidKind::Water, MAX_FLUID_LEVEL);
+        assert_eq!(clamped, max);
+    }
+}

--- a/src/lib/world/src/fluid/spread.rs
+++ b/src/lib/world/src/fluid/spread.rs
@@ -1,0 +1,350 @@
+//! Fluid spreading algorithm (simplified model).
+//!
+//! This module contains the pure decision logic for how a single fluid block evolves on its
+//! scheduled tick. It is deliberately decoupled from world storage, the ECS, and networking: it
+//! reads the world only through the [`BlockView`] trait and returns a list of [`FluidChange`]s
+//! describing what should happen, without mutating anything itself. This makes the rules
+//! independently unit-testable and easy to revise.
+//!
+//! # Simplified model
+//!
+//! The model approximates vanilla without the full "shortest path to a hole" search:
+//!
+//! * A block is a *source* (level 0) or *flowing* (level 1..=[`MAX_SPREAD_LEVEL`]).
+//! * If the cell below is replaceable, fluid flows straight down. Downward flow always produces a
+//!   near-source flowing block, so a falling column stays full.
+//! * Otherwise, fluid spreads horizontally to each replaceable neighbour whose resulting level
+//!   would be lower than that neighbour's current level, decrementing the level by one step each
+//!   block. Once the level passes [`MAX_SPREAD_LEVEL`], the fluid no longer spreads horizontally.
+//! * A flowing (non-source) block that has lost all of its upstream support dries up: it is
+//!   scheduled to be removed. (Upstream = a same-fluid source/flow above, or an adjacent block
+//!   with a stronger, i.e. lower, level.)
+//!
+//! Water and lava share this logic; they differ only in [`crate::fluid::FluidKind`]-derived
+//! parameters supplied by the caller (spread distance and tick delay live with the caller, not
+//! here).
+
+use crate::block_state_id::BlockStateId;
+use crate::fluid::{fluid_block, fluid_state, FluidKind, FluidState};
+use crate::pos::BlockPos;
+use ferrumc_macros::block;
+
+/// The maximum flowing level that still spreads horizontally. Vanilla water spreads 7 blocks from a
+/// source on flat ground; lava (overworld) spreads less, but the simplified model uses a single
+/// cap here and lets the caller pick the fluid kind. Levels above this are treated as "too thin to
+/// continue".
+pub const MAX_SPREAD_LEVEL: u8 = 7;
+
+/// A read-only view of block states around the position being ticked.
+///
+/// The algorithm only ever inspects the ticking block and its six axis-aligned neighbours, so any
+/// backing store (a live chunk, a test fixture, a snapshot) can implement this cheaply.
+pub trait BlockView {
+    /// Returns the block state at an absolute world position.
+    fn block_at(&self, pos: BlockPos) -> BlockStateId;
+}
+
+/// A single block mutation produced by a fluid tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FluidChange {
+    /// The position to modify.
+    pub pos: BlockPos,
+    /// The new block state to place there.
+    pub new_block: BlockStateId,
+    /// Whether the changed block should itself be scheduled for a follow-up fluid tick (because it
+    /// is flowing fluid that may continue to spread).
+    pub reschedule: bool,
+}
+
+/// Returns true if a fluid may overwrite this block.
+///
+/// The simplified model treats air and existing fluid of any kind as replaceable. Solid blocks are
+/// not. (Fluid-vs-fluid interactions such as water meeting lava are intentionally out of scope for
+/// this phase; they are recorded as future work.)
+fn is_replaceable(block: BlockStateId) -> bool {
+    block == block!("air") || block == block!("void_air") || fluid_state(block).is_some()
+}
+
+/// The six axis-aligned neighbours of `pos`, plus convenience accessors.
+fn below(pos: BlockPos) -> BlockPos {
+    pos + (0, -1, 0)
+}
+fn above(pos: BlockPos) -> BlockPos {
+    pos + (0, 1, 0)
+}
+const HORIZONTAL: [(i32, i32, i32); 4] = [(1, 0, 0), (-1, 0, 0), (0, 0, 1), (0, 0, -1)];
+
+/// Returns true if `neighbour` provides upstream support for a flowing block of `kind`.
+///
+/// Support comes from the same fluid directly above, or from a horizontally adjacent same-fluid
+/// block with a strictly stronger (lower) level.
+fn provides_support(kind: FluidKind, self_level: u8, neighbour: Option<FluidState>) -> bool {
+    match neighbour {
+        Some(state) if state.kind == kind => state.level < self_level,
+        _ => false,
+    }
+}
+
+/// Computes the changes a single fluid block produces on its tick.
+///
+/// `pos` must currently contain a fluid (otherwise an empty change set is returned). The returned
+/// changes are not applied; the caller is responsible for writing them back and for scheduling any
+/// follow-up ticks indicated by [`FluidChange::reschedule`].
+pub fn compute_fluid_tick<V: BlockView>(pos: BlockPos, view: &V) -> Vec<FluidChange> {
+    let current = view.block_at(pos);
+    let Some(state) = fluid_state(current) else {
+        return Vec::new();
+    };
+    let kind = state.kind;
+    let mut changes = Vec::new();
+
+    // --- Determine whether this block still has upstream support. ---
+    // Sources are always supported. Flowing blocks need either fluid above or a stronger
+    // horizontal neighbour.
+    let supported = if state.is_source() {
+        true
+    } else {
+        let above_state = fluid_state(view.block_at(above(pos)));
+        let above_supports = matches!(above_state, Some(s) if s.kind == kind);
+        above_supports
+            || HORIZONTAL.iter().any(|&offset| {
+                let n = fluid_state(view.block_at(pos + offset));
+                provides_support(kind, state.level, n)
+            })
+    };
+
+    // A flowing block with no support dries up.
+    if !supported {
+        changes.push(FluidChange {
+            pos,
+            new_block: block!("air"),
+            reschedule: false,
+        });
+        return changes;
+    }
+
+    // --- Vertical flow takes priority. ---
+    let below_pos = below(pos);
+    let below_block = view.block_at(below_pos);
+    if is_replaceable(below_block) {
+        // Falling fluid stays effectively full so columns do not thin out as they fall.
+        let falling = fluid_block(kind, 1);
+        if below_block != falling {
+            changes.push(FluidChange {
+                pos: below_pos,
+                new_block: falling,
+                reschedule: true,
+            });
+        }
+        // When fluid can fall, vanilla does not also spread horizontally from this block, so we
+        // stop here.
+        return changes;
+    }
+
+    // --- Horizontal spread. ---
+    // Only spread if we are not already too thin.
+    let next_level = state.level + 1;
+    if next_level > MAX_SPREAD_LEVEL {
+        return changes;
+    }
+
+    let outflow = fluid_block(kind, next_level);
+    for &offset in HORIZONTAL.iter() {
+        let n_pos = pos + offset;
+        let n_block = view.block_at(n_pos);
+        if !is_replaceable(n_block) {
+            continue;
+        }
+        // Only flow in if it would make the neighbour stronger (lower level) than it currently is.
+        let improves = match fluid_state(n_block) {
+            Some(n_state) if n_state.kind == kind => next_level < n_state.level,
+            Some(_) => false, // different fluid: skip in this phase
+            None => true,     // air: always flow in
+        };
+        if improves {
+            changes.push(FluidChange {
+                pos: n_pos,
+                new_block: outflow,
+                reschedule: true,
+            });
+        }
+    }
+
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Simple map-backed [`BlockView`] for tests. Any position not present is treated as air.
+    struct MapView {
+        blocks: HashMap<(i32, i32, i32), BlockStateId>,
+    }
+
+    impl MapView {
+        fn new() -> Self {
+            Self {
+                blocks: HashMap::new(),
+            }
+        }
+
+        fn set(&mut self, pos: BlockPos, block: BlockStateId) {
+            self.blocks.insert((pos.pos.x, pos.pos.y, pos.pos.z), block);
+        }
+    }
+
+    impl BlockView for MapView {
+        fn block_at(&self, pos: BlockPos) -> BlockStateId {
+            self.blocks
+                .get(&(pos.pos.x, pos.pos.y, pos.pos.z))
+                .copied()
+                .unwrap_or_else(|| block!("air"))
+        }
+    }
+
+    fn p(x: i32, y: i32, z: i32) -> BlockPos {
+        BlockPos::of(x, y, z)
+    }
+
+    #[test]
+    fn non_fluid_produces_no_changes() {
+        let mut view = MapView::new();
+        view.set(p(0, 64, 0), block!("stone"));
+        assert!(compute_fluid_tick(p(0, 64, 0), &view).is_empty());
+    }
+
+    #[test]
+    fn source_on_solid_ground_spreads_horizontally() {
+        let mut view = MapView::new();
+        // Water source with solid ground below so it cannot fall.
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 0));
+        view.set(p(0, 63, 0), block!("stone"));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        // Should flow into all 4 horizontal air neighbours at level 1.
+        assert_eq!(changes.len(), 4);
+        for c in &changes {
+            assert_eq!(c.new_block, fluid_block(FluidKind::Water, 1));
+            assert!(c.reschedule);
+            assert_eq!(c.pos.pos.y, 64);
+        }
+    }
+
+    #[test]
+    fn source_over_air_falls_instead_of_spreading() {
+        let mut view = MapView::new();
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 0));
+        // below is air (default)
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        assert_eq!(changes.len(), 1, "should only flow down, not sideways");
+        assert_eq!(changes[0].pos, p(0, 63, 0));
+        assert_eq!(changes[0].new_block, fluid_block(FluidKind::Water, 1));
+    }
+
+    #[test]
+    fn flowing_decrements_level_each_step() {
+        let mut view = MapView::new();
+        // A supported level-3 flowing block (source above) on solid ground spreads at level 4.
+        view.set(p(0, 65, 0), fluid_block(FluidKind::Water, 0));
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 3));
+        view.set(p(0, 63, 0), block!("stone"));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        // Ground below is solid and the block is supported, so it spreads sideways at level 4.
+        assert_eq!(changes.len(), 4);
+        for c in &changes {
+            assert_eq!(c.new_block, fluid_block(FluidKind::Water, 4));
+        }
+    }
+
+    #[test]
+    fn does_not_spread_past_max_level() {
+        let mut view = MapView::new();
+        // A supported block at MAX_SPREAD_LEVEL: next level would exceed the cap, so no spread.
+        view.set(p(0, 65, 0), fluid_block(FluidKind::Water, 0));
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, MAX_SPREAD_LEVEL));
+        view.set(p(0, 63, 0), block!("stone"));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        assert!(
+            changes.is_empty(),
+            "fluid at max level should not spread further"
+        );
+    }
+
+    #[test]
+    fn unsupported_flowing_block_dries_up() {
+        let mut view = MapView::new();
+        // A flowing block with solid ground below, air above, and no stronger neighbours.
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 3));
+        view.set(p(0, 63, 0), block!("stone"));
+        // surrounded by air horizontally, nothing above
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].pos, p(0, 64, 0));
+        assert_eq!(changes[0].new_block, block!("air"));
+        assert!(!changes[0].reschedule);
+    }
+
+    #[test]
+    fn flowing_block_with_source_above_is_supported() {
+        let mut view = MapView::new();
+        // Source above keeps this flowing block alive; ground below; it should spread, not dry up.
+        view.set(p(0, 65, 0), fluid_block(FluidKind::Water, 0));
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 1));
+        view.set(p(0, 63, 0), block!("stone"));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        // Supported, on solid ground -> spreads at level 2 into 4 neighbours.
+        assert_eq!(changes.len(), 4);
+        for c in &changes {
+            assert_eq!(c.new_block, fluid_block(FluidKind::Water, 2));
+        }
+    }
+
+    #[test]
+    fn does_not_overwrite_solid_neighbours() {
+        let mut view = MapView::new();
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 0));
+        view.set(p(0, 63, 0), block!("stone"));
+        view.set(p(1, 64, 0), block!("stone")); // solid wall to the east
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        // Only 3 open neighbours now.
+        assert_eq!(changes.len(), 3);
+        assert!(changes.iter().all(|c| c.pos != p(1, 64, 0)));
+    }
+
+    #[test]
+    fn does_not_reflow_into_equal_or_stronger_neighbour() {
+        let mut view = MapView::new();
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 0));
+        view.set(p(0, 63, 0), block!("stone"));
+        // East neighbour already level 1 (same as what we'd produce) -> no change there.
+        view.set(p(1, 64, 0), fluid_block(FluidKind::Water, 1));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        // 3 air neighbours get level 1; the existing level-1 neighbour is left alone.
+        assert_eq!(changes.len(), 3);
+        assert!(changes.iter().all(|c| c.pos != p(1, 64, 0)));
+    }
+
+    #[test]
+    fn lava_uses_its_own_states() {
+        let mut view = MapView::new();
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Lava, 0));
+        view.set(p(0, 63, 0), block!("stone"));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        assert_eq!(changes.len(), 4);
+        for c in &changes {
+            assert_eq!(c.new_block, fluid_block(FluidKind::Lava, 1));
+            // Ensure it is lava, not water.
+            assert_eq!(fluid_state(c.new_block).unwrap().kind, FluidKind::Lava);
+        }
+    }
+}

--- a/src/lib/world/src/fluid/spread.rs
+++ b/src/lib/world/src/fluid/spread.rs
@@ -23,17 +23,12 @@
 //! Water and lava share this logic; they differ only in [`crate::fluid::FluidKind`]-derived
 //! parameters supplied by the caller (spread distance and tick delay live with the caller, not
 //! here).
+//! til 2026-06-02, there is a crash problem due to(maybe) chunk storage. Placing any fluid may cause block disappear in a  specific section. It is fine, NCC is gonna fix it in another PR.
 
 use crate::block_state_id::BlockStateId;
-use crate::fluid::{fluid_block, fluid_state, FluidKind, FluidState};
+use crate::fluid::{fluid_block, fluid_state, FluidKind, FluidRules, FluidState};
 use crate::pos::BlockPos;
 use ferrumc_macros::block;
-
-/// The maximum flowing level that still spreads horizontally. Vanilla water spreads 7 blocks from a
-/// source on flat ground; lava (overworld) spreads less, but the simplified model uses a single
-/// cap here and lets the caller pick the fluid kind. Levels above this are treated as "too thin to
-/// continue".
-pub const MAX_SPREAD_LEVEL: u8 = 7;
 
 /// A read-only view of block states around the position being ticked.
 ///
@@ -87,10 +82,17 @@ fn provides_support(kind: FluidKind, self_level: u8, neighbour: Option<FluidStat
 
 /// Computes the changes a single fluid block produces on its tick.
 ///
-/// `pos` must currently contain a fluid (otherwise an empty change set is returned). The returned
-/// changes are not applied; the caller is responsible for writing them back and for scheduling any
-/// follow-up ticks indicated by [`FluidChange::reschedule`].
-pub fn compute_fluid_tick<V: BlockView>(pos: BlockPos, view: &V) -> Vec<FluidChange> {
+/// `pos` must currently contain a fluid (otherwise an empty change set is returned). `rules`
+/// supplies the per-fluid, per-dimension parameters (level step, max spread level); the caller is
+/// expected to look these up via [`FluidRules::for_kind`] using the block at `pos`.
+///
+/// The returned changes are not applied; the caller is responsible for writing them back and for
+/// scheduling any follow-up ticks indicated by [`FluidChange::reschedule`].
+pub fn compute_fluid_tick<V: BlockView>(
+    pos: BlockPos,
+    view: &V,
+    rules: FluidRules,
+) -> Vec<FluidChange> {
     let current = view.block_at(pos);
     let Some(state) = fluid_state(current) else {
         return Vec::new();
@@ -123,7 +125,7 @@ pub fn compute_fluid_tick<V: BlockView>(pos: BlockPos, view: &V) -> Vec<FluidCha
         return changes;
     }
 
-    // --- Vertical flow takes priority. ---
+    // --- Vertical flow takes priority. Or fluid will pruh~ pruh~ unfolded in the air ---
     let below_pos = below(pos);
     let below_block = view.block_at(below_pos);
     if is_replaceable(below_block) {
@@ -137,14 +139,16 @@ pub fn compute_fluid_tick<V: BlockView>(pos: BlockPos, view: &V) -> Vec<FluidCha
             });
         }
         // When fluid can fall, vanilla does not also spread horizontally from this block, so we
-        // stop here.
+        // stop here. And this code should be reviewed if it is conflict with chunk saving.
         return changes;
     }
 
     // --- Horizontal spread. ---
-    // Only spread if we are not already too thin.
-    let next_level = state.level + 1;
-    if next_level > MAX_SPREAD_LEVEL {
+    // The level step is fluid- and dimension-dependent: vanilla water steps by 1 (7 blocks of
+    // reach), overworld lava by 2 (3 blocks), nether lava by 1 (7 blocks). Saturating add so a
+    // pathological level near u8::MAX cannot wrap around.
+    let next_level = state.level.saturating_add(rules.level_step);
+    if next_level > rules.max_spread_level {
         return changes;
     }
 
@@ -208,11 +212,17 @@ mod tests {
         BlockPos::of(x, y, z)
     }
 
+    /// Convenience: vanilla water rules in the overworld. Most spread tests in this module care
+    /// about the underlying mechanics rather than per-fluid parameters, so they share this.
+    fn water_rules() -> FluidRules {
+        FluidRules::for_kind(FluidKind::Water, crate::dimension::Dimension::Overworld)
+    }
+
     #[test]
     fn non_fluid_produces_no_changes() {
         let mut view = MapView::new();
         view.set(p(0, 64, 0), block!("stone"));
-        assert!(compute_fluid_tick(p(0, 64, 0), &view).is_empty());
+        assert!(compute_fluid_tick(p(0, 64, 0), &view, water_rules()).is_empty());
     }
 
     #[test]
@@ -222,7 +232,7 @@ mod tests {
         view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 0));
         view.set(p(0, 63, 0), block!("stone"));
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, water_rules());
         // Should flow into all 4 horizontal air neighbours at level 1.
         assert_eq!(changes.len(), 4);
         for c in &changes {
@@ -238,7 +248,7 @@ mod tests {
         view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 0));
         // below is air (default)
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, water_rules());
         assert_eq!(changes.len(), 1, "should only flow down, not sideways");
         assert_eq!(changes[0].pos, p(0, 63, 0));
         assert_eq!(changes[0].new_block, fluid_block(FluidKind::Water, 1));
@@ -252,7 +262,7 @@ mod tests {
         view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 3));
         view.set(p(0, 63, 0), block!("stone"));
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, water_rules());
         // Ground below is solid and the block is supported, so it spreads sideways at level 4.
         assert_eq!(changes.len(), 4);
         for c in &changes {
@@ -263,12 +273,14 @@ mod tests {
     #[test]
     fn does_not_spread_past_max_level() {
         let mut view = MapView::new();
-        // A supported block at MAX_SPREAD_LEVEL: next level would exceed the cap, so no spread.
+        // A supported block at the rules' max level: next level would exceed the cap, so no
+        // spread.
+        let rules = water_rules();
         view.set(p(0, 65, 0), fluid_block(FluidKind::Water, 0));
-        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, MAX_SPREAD_LEVEL));
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Water, rules.max_spread_level));
         view.set(p(0, 63, 0), block!("stone"));
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, rules);
         assert!(
             changes.is_empty(),
             "fluid at max level should not spread further"
@@ -283,7 +295,7 @@ mod tests {
         view.set(p(0, 63, 0), block!("stone"));
         // surrounded by air horizontally, nothing above
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, water_rules());
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].pos, p(0, 64, 0));
         assert_eq!(changes[0].new_block, block!("air"));
@@ -298,7 +310,7 @@ mod tests {
         view.set(p(0, 64, 0), fluid_block(FluidKind::Water, 1));
         view.set(p(0, 63, 0), block!("stone"));
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, water_rules());
         // Supported, on solid ground -> spreads at level 2 into 4 neighbours.
         assert_eq!(changes.len(), 4);
         for c in &changes {
@@ -313,7 +325,7 @@ mod tests {
         view.set(p(0, 63, 0), block!("stone"));
         view.set(p(1, 64, 0), block!("stone")); // solid wall to the east
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, water_rules());
         // Only 3 open neighbours now.
         assert_eq!(changes.len(), 3);
         assert!(changes.iter().all(|c| c.pos != p(1, 64, 0)));
@@ -327,7 +339,7 @@ mod tests {
         // East neighbour already level 1 (same as what we'd produce) -> no change there.
         view.set(p(1, 64, 0), fluid_block(FluidKind::Water, 1));
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, water_rules());
         // 3 air neighbours get level 1; the existing level-1 neighbour is left alone.
         assert_eq!(changes.len(), 3);
         assert!(changes.iter().all(|c| c.pos != p(1, 64, 0)));
@@ -335,16 +347,63 @@ mod tests {
 
     #[test]
     fn lava_uses_its_own_states() {
+        use crate::dimension::Dimension;
+
         let mut view = MapView::new();
         view.set(p(0, 64, 0), fluid_block(FluidKind::Lava, 0));
         view.set(p(0, 63, 0), block!("stone"));
 
-        let changes = compute_fluid_tick(p(0, 64, 0), &view);
+        let lava = FluidRules::for_kind(FluidKind::Lava, Dimension::Overworld);
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, lava);
         assert_eq!(changes.len(), 4);
         for c in &changes {
-            assert_eq!(c.new_block, fluid_block(FluidKind::Lava, 1));
+            // Overworld lava steps by 2, so a source produces level-2 flow on adjacent blocks.
+            assert_eq!(c.new_block, fluid_block(FluidKind::Lava, lava.level_step));
             // Ensure it is lava, not water.
             assert_eq!(fluid_state(c.new_block).unwrap().kind, FluidKind::Lava);
+        }
+    }
+
+    #[test]
+    fn overworld_lava_caps_spread_short_of_water() {
+        use crate::dimension::Dimension;
+
+        // Overworld lava: level_step = 2, max_spread_level = 7. From a source we expect
+        // level 2 -> 4 -> 6 to be reachable (3 blocks); a level-6 block must not spread further
+        // because 6 + 2 = 8 > 7.
+        let lava = FluidRules::for_kind(FluidKind::Lava, Dimension::Overworld);
+        assert_eq!(lava.level_step, 2);
+
+        let mut view = MapView::new();
+        view.set(p(0, 65, 0), fluid_block(FluidKind::Lava, 0)); // support from above
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Lava, 6));
+        view.set(p(0, 63, 0), block!("stone"));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, lava);
+        assert!(
+            changes.is_empty(),
+            "overworld lava at level 6 should stop (next would be 8, > 7)"
+        );
+    }
+
+    #[test]
+    fn nether_lava_spreads_like_water() {
+        use crate::dimension::Dimension;
+
+        // Nether lava: level_step = 1, max_spread_level = 7 — same reach as water.
+        let lava = FluidRules::for_kind(FluidKind::Lava, Dimension::Nether);
+        assert_eq!(lava.level_step, 1);
+
+        let mut view = MapView::new();
+        view.set(p(0, 65, 0), fluid_block(FluidKind::Lava, 0));
+        view.set(p(0, 64, 0), fluid_block(FluidKind::Lava, 6));
+        view.set(p(0, 63, 0), block!("stone"));
+
+        let changes = compute_fluid_tick(p(0, 64, 0), &view, lava);
+        // Nether lava can still take one more step from level 6 -> 7.
+        assert_eq!(changes.len(), 4);
+        for c in &changes {
+            assert_eq!(c.new_block, fluid_block(FluidKind::Lava, 7));
         }
     }
 }

--- a/src/lib/world/src/fluid/tests_integration.rs
+++ b/src/lib/world/src/fluid/tests_integration.rs
@@ -7,8 +7,9 @@
 //! unit tests cannot show on their own.
 
 use crate::block_state_id::BlockStateId;
+use crate::dimension::Dimension;
 use crate::fluid::spread::{compute_fluid_tick, BlockView};
-use crate::fluid::{fluid_block, fluid_state, FluidKind};
+use crate::fluid::{fluid_block, fluid_state, FluidKind, FluidRules};
 use crate::pos::BlockPos;
 use crate::scheduler::{BlockTickScheduler, TickKind};
 use ferrumc_macros::block;
@@ -49,9 +50,12 @@ fn p(x: i32, y: i32, z: i32) -> BlockPos {
 }
 
 /// Runs the full scheduler-driven fluid loop for `ticks` game ticks, returning the number of block
-/// changes applied across the whole run. Mirrors the server's `process_fluid_ticks`.
+/// changes applied across the whole run. Mirrors the server's `process_fluid_ticks`: each due tick
+/// looks up the rules for the fluid currently at that position and feeds them to the algorithm.
 fn run(world: &mut MapWorld, scheduler: &mut BlockTickScheduler, start_tick: u64, ticks: u64) -> usize {
-    const DELAY: u64 = 5;
+    // All integration tests in this file run in the overworld, where water and lava use their
+    // own rules. The reschedule delay mirrors whichever fluid produced the change.
+    const DIM: Dimension = Dimension::Overworld;
     let mut total_changes = 0;
 
     for offset in 0..ticks {
@@ -65,16 +69,27 @@ fn run(world: &mut MapWorld, scheduler: &mut BlockTickScheduler, start_tick: u64
         let mut changes = Vec::new();
         for (_chunk, scheduled) in &due {
             for tick in scheduled {
-                changes.extend(compute_fluid_tick(tick.pos, &&*world));
+                let block = world.get(tick.pos);
+                let Some(state) = fluid_state(block) else {
+                    continue;
+                };
+                let rules = FluidRules::for_kind(state.kind, DIM);
+                changes.extend(compute_fluid_tick(tick.pos, &&*world, rules));
             }
         }
 
-        // Write phase: apply changes and re-schedule.
+        // Write phase: apply changes and re-schedule, using the rules for whatever the new block
+        // is (the changed block, not the source position, drives the follow-up cadence).
         for change in &changes {
             world.set(change.pos, change.new_block);
             total_changes += 1;
             if change.reschedule {
-                scheduler.schedule(change.pos, TickKind::FluidSpread, current, DELAY);
+                let delay = fluid_state(change.new_block)
+                    .map(|s| FluidRules::for_kind(s.kind, DIM).tick_delay)
+                    // Fallback for non-fluid changes (drying up): use the water cadence as a safe
+                    // default. In practice non-fluid changes set reschedule = false.
+                    .unwrap_or_else(|| FluidRules::for_kind(FluidKind::Water, DIM).tick_delay);
+                scheduler.schedule(change.pos, TickKind::FluidSpread, current, delay);
             }
         }
     }

--- a/src/lib/world/src/fluid/tests_integration.rs
+++ b/src/lib/world/src/fluid/tests_integration.rs
@@ -1,0 +1,229 @@
+//! Integration tests that drive the full fluid loop over multiple ticks.
+//!
+//! These exercise the [`scheduler`](crate::scheduler) and the spreading
+//! [`algorithm`](crate::fluid::spread) together against a mutable in-memory world, replicating the
+//! drain → evaluate → apply → re-schedule cycle the server runs each tick (minus the ECS and
+//! networking). They verify that spreading converges and respects terrain, which the per-function
+//! unit tests cannot show on their own.
+
+use crate::block_state_id::BlockStateId;
+use crate::fluid::spread::{compute_fluid_tick, BlockView};
+use crate::fluid::{fluid_block, fluid_state, FluidKind};
+use crate::pos::BlockPos;
+use crate::scheduler::{BlockTickScheduler, TickKind};
+use ferrumc_macros::block;
+use std::collections::HashMap;
+
+/// A mutable map-backed world. Missing positions read as air.
+struct MapWorld {
+    blocks: HashMap<(i32, i32, i32), BlockStateId>,
+}
+
+impl MapWorld {
+    fn new() -> Self {
+        Self {
+            blocks: HashMap::new(),
+        }
+    }
+
+    fn set(&mut self, pos: BlockPos, block: BlockStateId) {
+        self.blocks.insert((pos.pos.x, pos.pos.y, pos.pos.z), block);
+    }
+
+    fn get(&self, pos: BlockPos) -> BlockStateId {
+        self.blocks
+            .get(&(pos.pos.x, pos.pos.y, pos.pos.z))
+            .copied()
+            .unwrap_or_else(|| block!("air"))
+    }
+}
+
+impl BlockView for &MapWorld {
+    fn block_at(&self, pos: BlockPos) -> BlockStateId {
+        self.get(pos)
+    }
+}
+
+fn p(x: i32, y: i32, z: i32) -> BlockPos {
+    BlockPos::of(x, y, z)
+}
+
+/// Runs the full scheduler-driven fluid loop for `ticks` game ticks, returning the number of block
+/// changes applied across the whole run. Mirrors the server's `process_fluid_ticks`.
+fn run(world: &mut MapWorld, scheduler: &mut BlockTickScheduler, start_tick: u64, ticks: u64) -> usize {
+    const DELAY: u64 = 5;
+    let mut total_changes = 0;
+
+    for offset in 0..ticks {
+        let current = start_tick + offset;
+        let due = scheduler.drain_due(current);
+        if due.is_empty() {
+            continue;
+        }
+
+        // Read phase: evaluate all due ticks against the current world.
+        let mut changes = Vec::new();
+        for (_chunk, scheduled) in &due {
+            for tick in scheduled {
+                changes.extend(compute_fluid_tick(tick.pos, &&*world));
+            }
+        }
+
+        // Write phase: apply changes and re-schedule.
+        for change in &changes {
+            world.set(change.pos, change.new_block);
+            total_changes += 1;
+            if change.reschedule {
+                scheduler.schedule(change.pos, TickKind::FluidSpread, current, DELAY);
+            }
+        }
+    }
+
+    total_changes
+}
+
+#[test]
+fn water_source_spreads_across_flat_floor_over_time() {
+    let mut world = MapWorld::new();
+    let mut scheduler = BlockTickScheduler::new();
+
+    // Build a flat stone floor at y=63 across a small area.
+    for x in -8..=8 {
+        for z in -8..=8 {
+            world.set(p(x, 63, z), block!("stone"));
+        }
+    }
+    // Place a water source at the centre, on the floor.
+    let source = p(0, 64, 0);
+    world.set(source, fluid_block(FluidKind::Water, 0));
+    scheduler.schedule(source, TickKind::FluidSpread, 0, 5);
+
+    // Immediately after seeding, only the source exists.
+    assert!(fluid_state(world.get(p(1, 64, 0))).is_none());
+
+    // Run enough ticks for water to spread outward several blocks.
+    run(&mut world, &mut scheduler, 0, 60);
+
+    // The four direct neighbours should now hold flowing water.
+    for n in [p(1, 64, 0), p(-1, 64, 0), p(0, 64, 1), p(0, 64, -1)] {
+        let state = fluid_state(world.get(n))
+            .unwrap_or_else(|| panic!("expected water at {:?}", n.pos));
+        assert_eq!(state.kind, FluidKind::Water);
+        assert!(!state.is_source(), "neighbour should be flowing, not source");
+    }
+    // The source itself is untouched.
+    assert!(fluid_state(world.get(source)).unwrap().is_source());
+}
+
+#[test]
+fn water_falls_then_spreads_on_landing() {
+    let mut world = MapWorld::new();
+    let mut scheduler = BlockTickScheduler::new();
+
+    // Floor at y=60. Source up at y=64 with air between.
+    for x in -4..=4 {
+        for z in -4..=4 {
+            world.set(p(x, 60, z), block!("stone"));
+        }
+    }
+    let source = p(0, 64, 0);
+    world.set(source, fluid_block(FluidKind::Water, 0));
+    scheduler.schedule(source, TickKind::FluidSpread, 0, 5);
+
+    run(&mut world, &mut scheduler, 0, 120);
+
+    // Water should have fallen down the column to just above the floor.
+    for y in 61..=64 {
+        let state = fluid_state(world.get(p(0, y, 0)));
+        assert!(state.is_some(), "expected water in column at y={}", y);
+    }
+    // And spread along the floor at y=61.
+    let neighbour = fluid_state(world.get(p(1, 61, 0)));
+    assert!(
+        neighbour.is_some(),
+        "water should spread along the floor after falling"
+    );
+}
+
+#[test]
+fn water_does_not_pass_through_walls() {
+    let mut world = MapWorld::new();
+    let mut scheduler = BlockTickScheduler::new();
+
+    // Floor at y=63.
+    for x in -4..=4 {
+        for z in -4..=4 {
+            world.set(p(x, 63, z), block!("stone"));
+        }
+    }
+    // A wall one block east of the source.
+    world.set(p(1, 64, 0), block!("stone"));
+
+    let source = p(0, 64, 0);
+    world.set(source, fluid_block(FluidKind::Water, 0));
+    scheduler.schedule(source, TickKind::FluidSpread, 0, 5);
+
+    run(&mut world, &mut scheduler, 0, 60);
+
+    // The wall remains stone; water never overwrites it.
+    assert_eq!(world.get(p(1, 64, 0)), block!("stone"));
+    // Water did spread the other directions.
+    assert!(fluid_state(world.get(p(-1, 64, 0))).is_some());
+}
+
+#[test]
+fn run_eventually_reaches_a_steady_state() {
+    let mut world = MapWorld::new();
+    let mut scheduler = BlockTickScheduler::new();
+
+    // Fully enclosed basin so water cannot escape and must settle:
+    // - 7x7 stone floor at y=63
+    // - stone walls one block high around the perimeter (|x|==3 or |z|==3) at y=64
+    // This leaves a 5x5 interior (x,z in -2..=2) for water to fill.
+    for x in -3..=3 {
+        for z in -3..=3 {
+            world.set(p(x, 63, z), block!("stone"));
+            if x.abs() == 3 || z.abs() == 3 {
+                world.set(p(x, 64, z), block!("stone"));
+            }
+        }
+    }
+    let source = p(0, 64, 0);
+    world.set(source, fluid_block(FluidKind::Water, 0));
+    scheduler.schedule(source, TickKind::FluidSpread, 0, 5);
+
+    // Run a long time, then confirm no further changes occur (steady state).
+    run(&mut world, &mut scheduler, 0, 200);
+    let changes_after_settle = run(&mut world, &mut scheduler, 200, 60);
+    assert_eq!(
+        changes_after_settle, 0,
+        "fluid should reach a steady state with no further changes"
+    );
+}
+
+#[test]
+fn steady_state_stops_rescheduling() {
+    // Guards against a performance footgun: once a closed basin settles, the scheduler must
+    // empty out rather than re-queueing no-op ticks forever.
+    let mut world = MapWorld::new();
+    let mut scheduler = BlockTickScheduler::new();
+
+    for x in -3..=3 {
+        for z in -3..=3 {
+            world.set(p(x, 63, z), block!("stone"));
+            if x.abs() == 3 || z.abs() == 3 {
+                world.set(p(x, 64, z), block!("stone"));
+            }
+        }
+    }
+    let source = p(0, 64, 0);
+    world.set(source, fluid_block(FluidKind::Water, 0));
+    scheduler.schedule(source, TickKind::FluidSpread, 0, 5);
+
+    run(&mut world, &mut scheduler, 0, 400);
+    assert_eq!(
+        scheduler.pending_count(),
+        0,
+        "scheduler should drain to empty once fluid settles"
+    );
+}

--- a/src/lib/world/src/lib.rs
+++ b/src/lib/world/src/lib.rs
@@ -2,9 +2,11 @@ pub mod block_state_id;
 pub mod chunk;
 mod db_functions;
 pub mod errors;
+pub mod fluid;
 mod importing;
 mod player;
 pub mod pos;
+pub mod scheduler;
 pub mod vanilla_chunk_format;
 
 use crate::chunk::Chunk;

--- a/src/lib/world/src/lib.rs
+++ b/src/lib/world/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod block_state_id;
 pub mod chunk;
 mod db_functions;
+pub mod dimension;
 pub mod errors;
 pub mod fluid;
 mod importing;

--- a/src/lib/world/src/pos.rs
+++ b/src/lib/world/src/pos.rs
@@ -15,7 +15,7 @@ use bitcode_derive::{Decode, Encode};
 use deepsize::DeepSizeOf;
 use ferrumc_net_codec::net_types::network_position::NetworkPosition;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct BlockPos {
     /// (i26, i12, i26)
     pub pos: IVec3,

--- a/src/lib/world/src/scheduler/mod.rs
+++ b/src/lib/world/src/scheduler/mod.rs
@@ -1,0 +1,243 @@
+//! Scheduled block ticks.
+//!
+//! Some block behaviour does not happen instantly: fluids spread a few ticks after being
+//! disturbed, and other mechanics (planned for later) tick on their own cadence. This module
+//! provides the bookkeeping for "do something at this block position N ticks from now".
+//!
+//! # Design
+//!
+//! Scheduled ticks are partitioned **per chunk**. Each [`ChunkPos`] owns its own queue of pending
+//! ticks. This partitioning is deliberate: it lets a future parallel fluid stage process disjoint
+//! sets of chunks on separate threads without contending over a single global structure. The
+//! scheduler itself does no locking; callers decide how to share it (for example, behind the
+//! existing chunk cache or a dedicated resource).
+//!
+//! Scheduling is **idempotent per `(position, kind)` within a tick bucket**: scheduling the same
+//! block for the same work at an already-pending time does not create duplicate entries. This
+//! mirrors vanilla, where a block cannot have two identical pending ticks, and keeps the queues
+//! from growing without bound when many neighbours re-trigger the same block.
+
+use crate::pos::{BlockPos, ChunkPos};
+use std::collections::{HashMap, HashSet};
+
+/// The category of work a scheduled tick performs.
+///
+/// Kept separate from the fluid module so the scheduler has no dependency on fluid specifics;
+/// new tick kinds (redstone, crops, random block ticks) can be added here without touching the
+/// queue machinery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TickKind {
+    /// A fluid block should re-evaluate its spread.
+    FluidSpread,
+}
+
+/// A single pending block update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ScheduledTick {
+    pub pos: BlockPos,
+    pub kind: TickKind,
+    /// The absolute tick number (from `TickCounter`) at which this should run.
+    pub target_tick: u64,
+}
+
+/// Per-chunk queue of pending ticks.
+///
+/// Entries are kept in a flat vector and filtered by due time on drain. A dedup set guards against
+/// inserting an identical `(pos, kind, target_tick)` more than once. For the small per-chunk
+/// populations expected from fluid spreading this is cheaper and simpler than a binary heap; the
+/// structure can be upgraded later if profiling shows it matters.
+#[derive(Debug, Default)]
+struct ChunkTickQueue {
+    pending: Vec<ScheduledTick>,
+    seen: HashSet<(BlockPos, TickKind, u64)>,
+}
+
+impl ChunkTickQueue {
+    fn schedule(&mut self, tick: ScheduledTick) -> bool {
+        let key = (tick.pos, tick.kind, tick.target_tick);
+        if self.seen.insert(key) {
+            self.pending.push(tick);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn drain_due(&mut self, current_tick: u64, out: &mut Vec<ScheduledTick>) {
+        // Partition into due / not-yet-due, retaining the latter.
+        let mut remaining = Vec::with_capacity(self.pending.len());
+        for tick in self.pending.drain(..) {
+            if tick.target_tick <= current_tick {
+                self.seen.remove(&(tick.pos, tick.kind, tick.target_tick));
+                out.push(tick);
+            } else {
+                remaining.push(tick);
+            }
+        }
+        self.pending = remaining;
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+/// Scheduler holding per-chunk tick queues.
+///
+/// This is a plain data structure with no internal synchronization. It is intended to live in a
+/// single owner (e.g. an ECS resource) and be advanced once per game tick.
+#[derive(Debug, Default)]
+pub struct BlockTickScheduler {
+    chunks: HashMap<ChunkPos, ChunkTickQueue>,
+}
+
+impl BlockTickScheduler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Schedules `kind` work at `pos` to run `delay` ticks after `current_tick`.
+    ///
+    /// A `delay` of 0 schedules the work for the current tick (it will be returned by the next
+    /// [`drain_due`](Self::drain_due) call for `current_tick`). Returns `true` if a new tick was
+    /// added, or `false` if an identical tick was already pending.
+    pub fn schedule(
+        &mut self,
+        pos: BlockPos,
+        kind: TickKind,
+        current_tick: u64,
+        delay: u64,
+    ) -> bool {
+        let target_tick = current_tick.saturating_add(delay);
+        let chunk = pos.chunk();
+        self.chunks
+            .entry(chunk)
+            .or_default()
+            .schedule(ScheduledTick {
+                pos,
+                kind,
+                target_tick,
+            })
+    }
+
+    /// Removes and returns every tick due at or before `current_tick`, grouped by chunk.
+    ///
+    /// Only chunks that actually have due ticks appear in the result. Chunks whose queues become
+    /// empty are dropped to keep the map from accumulating idle entries. Grouping by chunk lets the
+    /// caller hand each chunk's work to a separate worker.
+    pub fn drain_due(&mut self, current_tick: u64) -> Vec<(ChunkPos, Vec<ScheduledTick>)> {
+        let mut result = Vec::new();
+        let mut emptied = Vec::new();
+
+        for (chunk_pos, queue) in self.chunks.iter_mut() {
+            let mut due = Vec::new();
+            queue.drain_due(current_tick, &mut due);
+            if !due.is_empty() {
+                result.push((*chunk_pos, due));
+            }
+            if queue.is_empty() {
+                emptied.push(*chunk_pos);
+            }
+        }
+
+        for chunk_pos in emptied {
+            self.chunks.remove(&chunk_pos);
+        }
+
+        result
+    }
+
+    /// Total number of chunks that currently have pending ticks. Primarily for diagnostics.
+    pub fn active_chunk_count(&self) -> usize {
+        self.chunks.len()
+    }
+
+    /// Total number of pending ticks across all chunks. Primarily for diagnostics.
+    pub fn pending_count(&self) -> usize {
+        self.chunks.values().map(|q| q.pending.len()).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pos(x: i32, y: i32, z: i32) -> BlockPos {
+        BlockPos::of(x, y, z)
+    }
+
+    #[test]
+    fn schedule_then_drain_at_target() {
+        let mut sched = BlockTickScheduler::new();
+        sched.schedule(pos(0, 64, 0), TickKind::FluidSpread, 100, 5);
+
+        // Nothing due before the target tick.
+        assert!(sched.drain_due(104).is_empty());
+        assert_eq!(sched.pending_count(), 1);
+
+        // Due exactly at the target tick.
+        let due = sched.drain_due(105);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].1.len(), 1);
+        assert_eq!(due[0].1[0].pos, pos(0, 64, 0));
+        assert_eq!(sched.pending_count(), 0);
+    }
+
+    #[test]
+    fn dedup_identical_ticks() {
+        let mut sched = BlockTickScheduler::new();
+        let first = sched.schedule(pos(1, 64, 1), TickKind::FluidSpread, 0, 5);
+        let second = sched.schedule(pos(1, 64, 1), TickKind::FluidSpread, 0, 5);
+        assert!(first);
+        assert!(!second, "identical pending tick should be deduplicated");
+        assert_eq!(sched.pending_count(), 1);
+    }
+
+    #[test]
+    fn different_target_ticks_not_deduped() {
+        let mut sched = BlockTickScheduler::new();
+        sched.schedule(pos(1, 64, 1), TickKind::FluidSpread, 0, 5);
+        sched.schedule(pos(1, 64, 1), TickKind::FluidSpread, 0, 6);
+        assert_eq!(sched.pending_count(), 2);
+    }
+
+    #[test]
+    fn groups_by_chunk() {
+        let mut sched = BlockTickScheduler::new();
+        // Two positions in different chunks (16 blocks apart horizontally).
+        sched.schedule(pos(0, 64, 0), TickKind::FluidSpread, 0, 1);
+        sched.schedule(pos(32, 64, 0), TickKind::FluidSpread, 0, 1);
+        sched.schedule(pos(1, 64, 0), TickKind::FluidSpread, 0, 1); // same chunk as first
+
+        let mut due = sched.drain_due(1);
+        due.sort_by_key(|(c, _)| c.x());
+        assert_eq!(due.len(), 2, "two distinct chunks should be present");
+        // First chunk has two ticks, second has one.
+        assert_eq!(due[0].1.len(), 2);
+        assert_eq!(due[1].1.len(), 1);
+    }
+
+    #[test]
+    fn drain_leaves_future_ticks() {
+        let mut sched = BlockTickScheduler::new();
+        sched.schedule(pos(0, 64, 0), TickKind::FluidSpread, 0, 1);
+        sched.schedule(pos(0, 65, 0), TickKind::FluidSpread, 0, 10);
+
+        let due = sched.drain_due(1);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].1.len(), 1);
+        assert_eq!(sched.pending_count(), 1);
+
+        // Re-scheduling the drained position is allowed again (dedup entry was cleared).
+        assert!(sched.schedule(pos(0, 64, 0), TickKind::FluidSpread, 1, 1));
+    }
+
+    #[test]
+    fn empty_chunks_are_pruned() {
+        let mut sched = BlockTickScheduler::new();
+        sched.schedule(pos(0, 64, 0), TickKind::FluidSpread, 0, 1);
+        assert_eq!(sched.active_chunk_count(), 1);
+        sched.drain_due(1);
+        assert_eq!(sched.active_chunk_count(), 0);
+    }
+}


### PR DESCRIPTION
feat: add fluid simulation with parallel tick evaluation

- ferrumc-core: add TickCounter resource (monotonic game tick counter)
- ferrumc-world: add fluid query table (water/lava level ↔ BlockStateId)
- ferrumc-world: add BlockTickScheduler (per-chunk scheduled tick queues,
  dedup, drain_due)
- ferrumc-world: add fluid spread algorithm (decoupled pure fn,
  BlockView trait, simplified model)
- bin: FluidScheduler ECS resource + process_fluid_ticks system
  (serial path for small batches, parallel path via ThreadPool for
  large batches, deterministic conflict reduction)
- bin: seed fluid ticks on block place and break (BlockBrokenEvent)
- bin: fix DashMap re-entrant write deadlock in place_block (drop
  chunk guard before seeding)
- BlockPos: derive Hash, Eq, PartialEq

(after many edition done, i have no idea what i have done. So i drive AI to make conclusions above)