### PR TITLE
docs(readme): announce active v2 rewrite on rework/v2-skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@
     </a>
 </div>
 
+> [!IMPORTANT]
+> ### 🚧 A ground-up **v2 rewrite** is under active development
+>
+> Most current work is happening on **[`rework/v2-skeleton`](https://github.com/ferrumc-rs/ferrumc/tree/rework/v2-skeleton)**, and we expect to **merge it into `master` soon**. Here's what v2 brings:
+>
+> - 🧱 **Clean, hard-separated architecture** — a deterministic, actor-sharded simulation layered as `net → session → sim → storage`, with bounded queues everywhere.
+> - 🎨 **Flat creative core** for vanilla **1.21.8** clients: correct block-state placement (logs, slabs, stairs, fences, doors, walls…), signs & chests, and region build commands (`/fill`, `/replace`, `/undo`).
+> - 🌗 **Day–night cycle** and richer multiplayer visibility (body/head rotation, held items, worn armor).
+> - 💾 **Persistence** across rejoin & restart, plus vanilla **Anvil** world import.
+> - 🔌 **In-process Rust plugin API** (allow / deny / replace edits) with C-ABI dynamic-loader groundwork.
+> - 📊 **Loopback observability dashboard** + Prometheus metrics.
+>
+> It's an **offline, local, alpha-quality** creative/minigame core — not vanilla parity, survival, or a Paper/Spigot replacement. Want to follow along or help out? Check out the branch above. 👀
+
 ## 📖 About
 
 FerrumC is a **1.21.8** Minecraft server implementation written from the ground up in Rust. Leveraging the power of the


### PR DESCRIPTION
Adds a prominent notice to the top of the `master` README pointing at the in-progress **v2 rewrite** on [`rework/v2-skeleton`](https://github.com/ferrumc-rs/ferrumc/tree/rework/v2-skeleton), summarizing what v2 brings, and flagging an upcoming merge.

Framing stays honest — offline, local, alpha-quality creative/minigame core, not vanilla parity — consistent with `docs/public-alpha.md`.

Only `README.md` changes (+14 lines). This must land on `master` to render on the repo homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)